### PR TITLE
Fix installation instructions for Claude Code project

### DIFF
--- a/pentest/README.md
+++ b/pentest/README.md
@@ -144,30 +144,25 @@ Before vulnerability testing, comprehensive reconnaissance is performed:
 
 ### Prerequisites
 
-- [Claude Code](https://claude.ai/code) installed
-- Python 3.8+
-- Common security tools (optional but recommended):
-  - `ffuf`, `gobuster`, `nikto` (for directory scanning)
-  - `sqlmap` (for SQL injection)
-  - `nuclei` (for CVE testing)
+- **[Claude Code](https://claude.ai/code)** - Required for running the framework
+- **Security Testing Tools** (optional but recommended for enhanced capabilities):
+  - `ffuf`, `gobuster`, `nikto` - Directory and file enumeration
+  - `sqlmap` - Advanced SQL injection testing
+  - `nuclei` - CVE and vulnerability scanning
+  - `nmap` - Port scanning and service detection
+
+**Note:** Claude Code handles the execution environment. No Python dependencies need to be installed manually - Claude will manage any required packages during agent execution.
 
 ### Installation
 
-1. **Clone this repository into your Claude Code skills directory:**
+1. **Clone this repository to your working directory:**
 
 ```bash
-cd ~/.claude/skills/
 git clone https://github.com/transilienceai/communitytools.git
 cd communitytools/pentest
 ```
 
-2. **Install Python dependencies:**
-
-```bash
-pip install -r requirements.txt
-```
-
-3. **Verify installation:**
+2. **Verify the framework structure:**
 
 ```bash
 # List available agents
@@ -176,6 +171,8 @@ ls .claude/agents/
 # List available skills
 ls .claude/skills/
 ```
+
+3. **That's it!** Claude Code will automatically detect and use the agents and skills in this directory.
 
 ### Basic Usage
 
@@ -330,7 +327,6 @@ pentest/
 │   ├── cve-tester/
 │   └── ...
 ├── README.md               # This file
-├── requirements.txt        # Python dependencies
 └── LICENSE                 # MIT License
 ```
 


### PR DESCRIPTION
## Summary

Fixes invalid installation instructions in the Pentest Framework README that referenced a non-existent `requirements.txt` file.

## Related Issue

Addresses #3 

## Problem

The README contained misleading installation instructions:
- Referenced `pip install -r requirements.txt` but the file doesn't exist
- Listed Python 3.8+ as a prerequisite when Claude Code manages the environment
- Implied manual dependency installation was needed for a Claude Code project

This caused confusion for contributors trying to set up the framework.

## Changes Made

- ✅ Removed invalid `requirements.txt` installation step
- ✅ Removed Python version prerequisite (Claude Code handles this)
- ✅ Added clear note that Claude Code manages the execution environment
- ✅ Updated directory structure diagram to remove `requirements.txt`
- ✅ Simplified installation to 3 clear steps: clone, verify, done
- ✅ Enhanced security tools documentation with descriptions

## Testing

- ✓ Verified all references to `requirements.txt` removed from README
- ✓ Installation instructions now accurately reflect Claude Code project setup
- ✓ Documentation is clear for new contributors

## Impact

This makes it easier for contributors to:
- Understand how Claude Code projects work
- Get started without confusion about missing files
- Focus on using the framework rather than troubleshooting installation

---

**Note:** Claude Code projects use agents (markdown files) that Claude interprets directly. No traditional Python package installation is required - Claude manages dependencies during execution.