### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,111 @@
+name: Bug Report
+description: Report a bug or false positive in a skill, agent, or tool
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project is affected?
+      options:
+        - Skill (vulnerability testing)
+        - Skill (reconnaissance)
+        - Skill (specialized)
+        - Skill (platform integration)
+        - Skill (orchestration/tooling)
+        - Agent
+        - Tool integration (Playwright)
+        - Tool integration (Kali tools)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: skill-or-agent
+    attributes:
+      label: Skill / Agent name
+      description: Which specific skill or agent? (e.g. `/injection`, `pentester-orchestrator`)
+      placeholder: "/skill-name or agent-name"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear description of what went wrong.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      value: |
+        1. Run skill/agent: `...`
+        2. With target/input: `...`
+        3. Observe: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages, false positives, or incorrect output.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: bug-type
+    attributes:
+      label: Bug type
+      description: What kind of bug is this?
+      options:
+        - False positive (flagged something that isn't a vulnerability)
+        - False negative (missed a real vulnerability)
+        - Crash / error
+        - Incorrect output format
+        - Performance issue
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide details about your setup.
+      value: |
+        - OS:
+        - Claude Code version:
+        - Python version:
+        - Target application (if applicable):
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste relevant logs, output, or attach screenshots.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/transilienceai/communitytools/discussions/new?category=q-a
+    about: Ask the community for help or guidance
+  - name: Share an Idea
+    url: https://github.com/transilienceai/communitytools/discussions/new?category=ideas
+    about: Share ideas that aren't ready to be a formal feature request
+  - name: Security Vulnerability
+    url: mailto:contact@transilience.ai
+    about: Report security vulnerabilities privately via email (do NOT open a public issue)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature Request
+description: Suggest a new feature, improvement, or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve the project? We'd love to hear it!
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What area does this feature relate to?
+      options:
+        - New vulnerability coverage
+        - Improve existing skill/agent
+        - New tool integration
+        - Reporting / output
+        - Documentation
+        - CI/CD / automation
+        - Developer experience
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve? Why is it needed?
+      placeholder: "I'm frustrated when... / It would be useful to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered other approaches? What are the trade-offs?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: willingness
+    attributes:
+      label: Contribution
+      description: Would you be willing to work on this?
+      options:
+        - "Yes, I'd like to submit a PR"
+        - "I can help but need guidance"
+        - "No, just suggesting"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, references, or links.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_skill_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/new_skill_proposal.yml
@@ -1,0 +1,97 @@
+name: New Skill Proposal
+description: Propose a new Claude Code skill for security testing
+title: "[Skill]: "
+labels: ["new-skill", "discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Proposing a new skill? Great! Please provide enough detail so maintainers can evaluate the scope and fit.
+
+        **Tip:** You can also use the `/skiller` command inside Claude Code to scaffold and submit skills automatically.
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+      description: The slash command name (lowercase, hyphens only).
+      placeholder: "e.g. mobile-security, graphql-fuzzing"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Where does this skill fit?
+      options:
+        - Vulnerability testing
+        - Reconnaissance
+        - Specialized
+        - Platform integration
+        - Orchestration / tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What does this skill do? What security testing capability does it add?
+    validations:
+      required: true
+
+  - type: textarea
+    id: techniques
+    attributes:
+      label: Techniques / attack types covered
+      description: List the specific techniques, attack types, or standards this skill will cover.
+      placeholder: |
+        - Technique 1
+        - Technique 2
+        - OWASP/CWE/MITRE mapping (if applicable)
+    validations:
+      required: true
+
+  - type: textarea
+    id: existing-coverage
+    attributes:
+      label: Overlap with existing skills
+      description: Does this overlap with any of the 23 existing skills? How is it different?
+      placeholder: "This differs from /injection because..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reference-materials
+    attributes:
+      label: Reference materials
+      description: Links to cheat sheets, OWASP pages, PayloadsAllTheThings sections, or other references you'd include.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: tool-dependencies
+    attributes:
+      label: External tool dependencies
+      description: Does this skill require tools beyond Claude Code?
+      options:
+        - None (Claude Code only)
+        - Playwright (browser automation)
+        - Kali Linux tools (nmap, sqlmap, etc.)
+        - Other external tools
+    validations:
+      required: true
+
+  - type: dropdown
+    id: willingness
+    attributes:
+      label: Contribution
+      description: Would you like to build this skill?
+      options:
+        - "Yes, I'll submit a PR"
+        - "I can help but need guidance"
+        - "No, just proposing the idea"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+## Summary
+
+<!-- Brief description of what this PR does. 1-3 sentences. -->
+
+## Related Issue
+
+<!-- REQUIRED: Link the issue this PR addresses. PRs without a linked issue will not be merged. -->
+
+Closes #
+
+## Changes Made
+
+<!-- Bullet list of specific changes. -->
+
+-
+
+## Type of Change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New skill or agent
+- [ ] Enhancement to existing skill/agent
+- [ ] Documentation update
+- [ ] CI/CD or infrastructure
+- [ ] Refactoring (no functional change)
+- [ ] Other: <!-- describe -->
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] Tested skill/agent in Claude Code session
+- [ ] Tested against vulnerable application (DVWA, WebGoat, Juice Shop, etc.)
+- [ ] Verified no false positives
+- [ ] Ran existing tests (`python -m pytest tests/`)
+- [ ] Manual review only (documentation/config changes)
+
+**Test details:**
+
+<!-- Describe what you tested and the results. -->
+
+## Checklist
+
+- [ ] My code follows the [contribution guidelines](../CONTRIBUTING.md)
+- [ ] Commits use conventional format: `type(scope): description`
+- [ ] I've updated documentation where needed
+- [ ] New skills include `SKILL.md` and `reference/` directory
+- [ ] No secrets, credentials, or unauthorized target information included
+- [ ] This PR links to an issue with `Closes #N`
+
+## Screenshots / Evidence
+
+<!-- If applicable, add screenshots, logs, or output samples. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this repository — such as a malicious payload in reference files, credential leaks, unsafe default configurations, or dependency vulnerabilities — please report it **privately**.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Email **[contact@transilience.ai](mailto:contact@transilience.ai)** with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected files or components
+- Potential impact
+- Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours
+- **Status update** within 7 days
+- **Resolution target** within 30 days for confirmed vulnerabilities
+
+We will coordinate with you on disclosure timing and credit you in the fix (unless you prefer to remain anonymous).
+
+## Scope
+
+This policy covers vulnerabilities **in this repository**, including:
+
+- Skills, agents, and their reference materials
+- Tool integration scripts (Playwright, Kali tools)
+- Build scripts and CI/CD configurations
+- Dependencies and supply chain issues
+- Documentation that could lead to unsafe practices
+
+### Out of Scope
+
+- Vulnerabilities found in **target applications** while using these tools — follow the target's own disclosure policy
+- General security testing questions — use [GitHub Discussions](https://github.com/transilienceai/communitytools/discussions)
+
+## Responsible Use Reminder
+
+This repository provides tools for **authorized security testing only**. Users are responsible for:
+
+- Obtaining proper authorization before testing any system
+- Following responsible disclosure timelines (typically 90 days)
+- Complying with all applicable laws and regulations
+
+See [README.md](README.md#security--legal) for full usage guidelines.


### PR DESCRIPTION
## Summary

Adds structured GitHub issue templates and a pull request template to standardize contributions. This was a missing piece — CLAUDE.md and CONTRIBUTING.md both reference templates that didn't exist yet.

Closes #14

## Changes Made

- `.github/ISSUE_TEMPLATE/bug_report.yml` — Form-based bug/false-positive reporting with dropdowns for component, skill name, and bug type
- `.github/ISSUE_TEMPLATE/feature_request.yml` — Feature proposals with category selection and contribution willingness
- `.github/ISSUE_TEMPLATE/new_skill_proposal.yml` — Repo-specific template for new skill proposals (category, techniques, overlap check, tool deps)
- `.github/ISSUE_TEMPLATE/config.yml` — Disables blank issues, routes questions to Discussions, security reports to email
- `.github/pull_request_template.md` — PR checklist aligned with CONTRIBUTING.md conventions

## Type of Change

- [x] CI/CD or infrastructure
- [x] Documentation update

## Testing

- [x] Manual review only (documentation/config changes)
- Validated YAML syntax for all issue template files
- Verified template structure follows GitHub's YAML form schema

## Checklist

- [x] My code follows the [contribution guidelines](../CONTRIBUTING.md)
- [x] Commits use conventional format: `type(scope): description`
- [x] I've updated documentation where needed
- [x] No secrets, credentials, or unauthorized target information included
- [x] This PR links to an issue with `Closes #N`