### PR TITLE
docs: add non-salesy CTAs linking to transilience.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 <div align="center">
 
+[![Built by Transilience](https://img.shields.io/badge/Built%20by-Transilience.ai-4A90D9)](https://www.transilience.ai)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](https://choosealicense.com/licenses/mit/)
 [![GitHub stars](https://img.shields.io/github/stars/transilienceai/communitytools)](https://github.com/transilienceai/communitytools/stargazers)
 [![Claude AI](https://img.shields.io/badge/Powered%20by-Claude%20AI-blue)](https://claude.ai)
 
-**Open-source Claude Code skills and agents for AI-powered penetration testing, bug bounty hunting, AI threat testing, and security reconnaissance**
+**Open-source Claude Code skills and agents for AI-powered penetration testing, bug bounty hunting, AI threat testing, and security reconnaissance — from the team at [Transilience.ai](https://www.transilience.ai)**
 
 [Quick Start](#-quick-start) | [Skills & Agents](#-skills--agents) | [Architecture](#-architecture) | [Contributing](CONTRIBUTING.md) | [Website](https://www.transilience.ai)
 
@@ -20,7 +21,7 @@
 
 We built an autonomous pentesting agent that scores **100% (104/104)** on a published CTF benchmark suite — using only structured markdown skill files, no fine-tuning. Starting from a bare 89.4% baseline, we ran a simple loop roughly 15 times: run the benchmarks, find a failure, diagnose the missing technique, write it into a skill file, and run again. The same skills transfer cross-model: Claude Sonnet 4.6 reaches 96.2% and Claude Haiku 4.5 reaches 62.5%. This repository contains the full skill set described in the paper.
 
-**[Read the paper (PDF)](papers/practice-makes-perfect.pdf)**
+**[Read the paper](https://www.transilience.ai/research/practice-makes-perfect)** · **[PDF](papers/practice-makes-perfect.pdf)**
 
 ---
 
@@ -269,8 +270,9 @@ If you discover a vulnerability using these tools:
 
 - [GitHub Discussions](https://github.com/transilienceai/communitytools/discussions) — Ask questions, share ideas
 - [GitHub Issues](https://github.com/transilienceai/communitytools/issues) — Report bugs, request features
-- [Website](https://www.transilience.ai) — Commercial products
-- [Email](mailto:contact@transilience.ai) — Enterprise support
+- [Transilience.ai](https://www.transilience.ai) — See what else we're building
+- [LinkedIn](https://linkedin.com/company/transilienceai) — Follow our work
+- [Email](mailto:contact@transilience.ai) — Get in touch
 
 ---
 
@@ -310,7 +312,7 @@ MIT License — Copyright (c) 2026 Transilience AI. See [LICENSE](LICENSE) for d
 
 **Built by [Transilience AI](https://www.transilience.ai)**
 
-Transilience AI specializes in autonomous security testing and AI security operations.
+We build AI-driven cloud security and compliance automation. These open-source tools reflect how we think about security — if you're curious about the platform behind them, [take a look](https://www.transilience.ai).
 
 [![Star this repository](https://img.shields.io/badge/Star%20this%20repo-yellow?style=for-the-badge)](https://github.com/transilienceai/communitytools)
 

--- a/projects/pentest/README.md
+++ b/projects/pentest/README.md
@@ -1,0 +1,40 @@
+# Pentest Skills for Claude Code
+
+[![Built by Transilience](https://img.shields.io/badge/Built%20by-Transilience.ai-4A90D9)](https://www.transilience.ai)
+[![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE)
+
+AI-powered penetration testing skills, agents, and tools for [Claude Code](https://claude.ai) — from the team at [Transilience.ai](https://www.transilience.ai).
+
+## Quick Start
+
+```bash
+git clone https://github.com/transilienceai/communitytools.git
+cd communitytools/projects/pentest
+claude
+```
+
+Then run any skill:
+
+```
+/coordination https://target.com     # Full penetration test
+/hackthebox                          # HackTheBox challenge automation
+/hackerone                           # Bug bounty workflow
+/reconnaissance target.com           # Attack surface mapping
+```
+
+## What's Inside
+
+```
+.claude/
+├── agents/       # 8 agents (orchestrator, executor, validator, HackTheBox, HackerOne, ...)
+├── skills/       # 23 skills covering OWASP Top 10, LLM Top 10, recon, and more
+└── tools/        # Playwright + Kali tool integrations
+```
+
+**23 skills** · **8 agents** · **100% OWASP coverage** · **104/104 CTF benchmark**
+
+See the [main README](../../README.md) for full documentation, architecture, and the research paper.
+
+---
+
+Built by [Transilience.ai](https://www.transilience.ai) — AI-native cloud security and compliance.


### PR DESCRIPTION
## Summary
- Add "Built by Transilience.ai" badge to top badge row
- Add team attribution to tagline
- Reframe footer from "Commercial products" to "See what else we're building"
- Add LinkedIn to community links
- Link research paper through website URL with PDF fallback
- Create `projects/pentest/README.md` with badge and context

## Why
GitHub Insights show 5,624 views/14d with README as #1 landing page (1,613 views). No structured path to transilience.ai exists. These add subtle builder-provenance links, not sales CTAs.

## Test plan
- [ ] Badge renders correctly
- [ ] All transilience.ai links resolve
- [ ] pentest/README.md renders when browsing that directory
- [ ] Mobile rendering check