### PR TITLE
docs(pentest): improve network exposure reporting

### DIFF
--- a/.claude/workflows/pentest-engagement.js
+++ b/.claude/workflows/pentest-engagement.js
@@ -8,7 +8,7 @@ export const meta = {
     { title: 'Scan', detail: 'NETWORK: slice the IP/CIDR set into machine-prudent batches; one nmap worker per slice (host discovery + bounded common+less-common port/service scan + CVE surfacing); uniform per-IP output tree' },
     { title: 'Assess', detail: 'WEB: per asset coordinator-loop (coverage) -> validate-findings. NETWORK: bounded coordinator-loop deep-dives on ONLY the highest-value hosts -> validate-findings' },
     { title: 'Correlate', detail: 'attack-path-stitcher across all validated findings -> risk-prioritiser -> ranked org roadmap' },
-    { title: 'Report', detail: 'Transilience PDF over the validated+ranked set; gated COMPLETE (web: coverage; network: scan completion)' },
+    { title: 'Report', detail: 'Transilience PDF over the validated+ranked set; network reports include coverage semantics, no-response watchlist, DNS reconciliation, attacker-use narrative, and safe verification POCs; gated COMPLETE (web: coverage; network: scan completion)' },
   ],
 }
 
@@ -353,12 +353,12 @@ if (KIND === 'network') {
   let reportNet = { ok: false }
   if (wantReport) {
     reportNet = await agent(
-      `ROLE: engagement REPORT (NETWORK vuln scan). cwd is repo root. Produce the Transilience PDF over the whole scan. Mount formats/transilience-report-style/pentest-report.md and formats/transilience-report-style/SKILL.md.\n` +
+      `ROLE: engagement REPORT (NETWORK vuln scan). cwd is repo root. Produce the Transilience PDF over the whole scan. Mount formats/transilience-report-style/pentest-report.md, formats/transilience-report-style/SKILL.md, and skills/pentest-engagement/reference/network-exposure-reporting.md.\n` +
       `ENGAGEMENT_DIR: ${engagementDir}\nINVENTORY: ${engagementDir}/recon/inventory/hosts.json + scan-summary.md\nDEEPENED_HOST_DIRS: ${JSON.stringify(netAssetDirs)}\nRANKED_PATHS: ${correlateNet && correlateNet.ranked_path ? correlateNet.ranked_path : `${engagementDir}/artifacts/attack-paths-ranked.md`}\nENGAGEMENT_STATUS: ${netEngagementStatus}\nSCAN_PROFILE: ${scanProfile} (ports: ${portSpec})\nTOOL_LIMITATIONS: ${JSON.stringify(scanLimitations)}\nHOSTS: ${liveCount} live / ~${deadCount} dead of ~${hostEstimate} targeted; deep-dived ${deepenHosts.length}.\n\n` +
       `Do:\n` +
       `1. Aggregate every ${engagementDir}/hosts/*/host.json + every deepened host's artifacts/validated/*.json (VALIDATED only) + the ranked paths into ${engagementDir}/artifacts/pentest-report.json (schema §8) and ${engagementDir}/reports/pentest-report-source.md (structure §4; findings grouped CRITICAL->LOW). Score on root cause (§7.1).\n` +
-      `2. Scope & Methodology section: targets (~${hostEstimate} hosts), the host-discovery method, the COMMON+LESS-COMMON port profile ACTUALLY scanned (state it is NOT all 65535 unless -p-), and the per-host uniform pipeline. Include a Host Inventory / service matrix (the breadth evidence: live hosts, open ports, service versions) and a CVE table. Name every TOOL_LIMITATION explicitly (e.g. nuclei/vulners absent).\n` +
-      `3. Be honest about depth: hosts beyond the top ${deepenHosts.length} were scanned UNIFORMLY but not deep-dived; scanner-derived CVE findings are flagged as such versus the validated deep-dive findings. Include a Positive Controls section.\n` +
+      `2. Scope & Methodology section: targets (~${hostEstimate} hosts), the host-discovery method, the COMMON+LESS-COMMON port profile ACTUALLY scanned (state it is NOT all 65535 unless -p-), and the per-host uniform pipeline. Include what was tested, what was not tested, UDP/tool caveats, a Host Inventory / service matrix (the breadth evidence: live hosts, open ports, service versions), a no-response watchlist for supplied targets, DNS/scope reconciliation when hostnames are available, and a CVE table. Name every TOOL_LIMITATION explicitly (e.g. nuclei/vulners absent). Do not claim unlisted ports are permanently closed; use the wording from network-exposure-reporting.md.\n` +
+      `3. Be honest about depth: hosts beyond the top ${deepenHosts.length} were scanned UNIFORMLY but not deep-dived; scanner-derived CVE findings are flagged as such versus the validated deep-dive findings. Include an attacker-use / attack-path narrative for high-value exposed roles, a Positive Controls section, a remediation roadmap, and safe verification POCs with expected current and expected fixed results.\n` +
       `4. Generate ${engagementDir}/reports/Penetration-Test-Report.pdf via ReportLab. No emoji; text severity labels.\n` +
       `5. COMPLETED Slack ONLY if Slack creds set AND engagement_status==COMPLETE. Concise summary (hosts live, severity rollup, top CVEs/paths). Non-blocking.\n\n` +
       `Return REPORT_SCHEMA (report_path, json_path, severity_rollup, slack_sent, slack_skipped_reason).`,

--- a/formats/transilience-report-style/pentest-report.md
+++ b/formats/transilience-report-style/pentest-report.md
@@ -65,10 +65,18 @@ Parts I-II for executives. Part III for technical staff. Part IV for remediation
 ### Part II — Scope & Methodology
 - In-scope systems table (system, URL/IP, testing type)
 - Out-of-scope, testing constraints
+- What was tested, what was not tested, and explicit tool/runtime limitations
 - Testing standards (PTES, OWASP WSTG, NIST SP 800-115)
 - Testing phases (Recon, Vuln Assessment, Exploitation, Post-Exploitation, Reporting)
 - CVSS v3.1 rating system
 - Infrastructure overview (tech stack, open ports, SSL/TLS)
+
+For NETWORK mode, add:
+- TCP/UDP coverage statement with exact scan profile and target/port math
+- Confirmed open-service matrix
+- No-response watchlist using "no TCP listener accepted a connection during the scan window" wording
+- DNS/scope reconciliation table
+- Attacker-use / attack-path narrative for high-value exposed roles
 
 ### Part III — Detailed Findings
 - Grouped by severity: CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL
@@ -116,6 +124,14 @@ Every finding MUST include all sections below.
 - Automated PoC script in `reports/appendix/finding-{id}/poc.py`
 - PoC output in `reports/appendix/finding-{id}/poc_output.txt`
 - PoC MUST be verified
+
+For network exposure and vulnerability-assessment findings, a PoC may be a safe verification test rather than an exploit. Include:
+- Verification command or console check
+- Expected current/vulnerable result
+- Expected remediated result
+- Explicit boundary of what was not attempted, such as no credential attack, no account disclosure, no state-changing HTTP method, no exploit payload, or no DoS
+
+Examples: `curl -skI` header checks, `nmap -sT -Pn -p PORTS -sV TARGET`, `openssl s_client ... | openssl x509 -noout -dates`, or a read-only protocol handshake that stops before application mutation.
 
 **PoC Script Template**:
 ```python
@@ -276,9 +292,11 @@ Generate `{OUTPUT_DIR}/artifacts/pentest-report.json` alongside the PDF:
 Run before delivery:
 
 - [ ] Every finding has unique ID (F-NNN), CVSS v3.1 + full vector, CWE + OWASP mapping
-- [ ] Every finding has verified PoC script, visual evidence, actionable remediation with code
+- [ ] Every finding has verified PoC script or safe verification test, evidence, actionable remediation, and fixed-state validation steps
 - [ ] Every finding has business impact analysis
 - [ ] Executive summary is 2 pages max
+- [ ] Report states what was tested, what was not tested, and tool/runtime limitations
+- [ ] Network reports include TCP/UDP coverage, no-response watchlist, DNS reconciliation, and attacker-use / attack-path narrative
 - [ ] No emoji — text severity labels only (CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL)
 - [ ] Finding metadata in tables (not bullet lists)
 - [ ] All evidence paths correct and files exist

--- a/skills/infrastructure/reference/port-scanning-quickstart.md
+++ b/skills/infrastructure/reference/port-scanning-quickstart.md
@@ -26,6 +26,25 @@ masscan target -p0-65535 --rate=1000
 nmap -sC -sV -p 80,443,22,21 target
 ```
 
+## Reporting Semantics
+
+Be precise in reports:
+
+- Use `confirmed open` only when the scanner observed a listener (`syn-ack`, completed TCP connect, or service data).
+- For unlisted TCP ports, say `no TCP listener accepted a connection during the scan window` instead of `closed`, unless the tool specifically returned a closed/RST state and that distinction matters.
+- Treat `filtered`, `dropped`, timeouts, geofencing, source allowlists, and temporary outages as separate from "closed".
+- State whether the scan was SYN (`-sS`) or TCP connect (`-sT`); non-root runners often fall back to `-sT`.
+- State UDP coverage separately. If UDP was not run because root privileges were unavailable, say so.
+- If a `standard` profile overlaps with a later full/high-port pass, distinguish unique coverage from total attempts.
+
+Example wording:
+
+```text
+Every TCP port 1-65535 was attempted for each supplied IP. Ports not listed as open did not accept a TCP connection from the scanner during the test window. This does not prove the ports are permanently closed; filtered, source-restricted, or temporarily unavailable services can appear the same externally. UDP was not assessed from this runner.
+```
+
+For NETWORK-mode reports, also include an open-service matrix, no-response watchlist, DNS reconciliation, tool limitations, and safe remediation verification commands. See `../../pentest-engagement/reference/network-exposure-reporting.md`.
+
 ## Methodology
 1. Host discovery (ping sweep, ARP scan)
 2. Port scanning (top 1000, then full)

--- a/skills/pentest-engagement/SKILL.md
+++ b/skills/pentest-engagement/SKILL.md
@@ -37,7 +37,7 @@ Write the scope file per [`reference/scope-file-format.md`](reference/scope-file
    **Scan** *(NETWORK, replaces Expand)* — slice the IP/CIDR set into machine-prudent batches; **one nmap worker per slice** (agents scale with *slices* ≈ dozens, never with IP count) runs the SAME pipeline: host discovery (reachability is unknown) → bounded common+less-common port/service scan → CVE surfacing (`nmap --script vulners`, `nuclei`, each CVE-ID enriched via `tools/nvd-lookup.py`) → writes a **uniform per-IP tree** `hosts/<ip>/{recon,host.json,findings}` + a merged `recon/inventory/`.
 3. **Assess** — WEB: each asset → `coordinator-loop` (**coverage mode**) → `validate-findings`. NETWORK: bounded `coordinator-loop` deep-dives on **only** the `deepen_top` highest-value hosts → `validate-findings` (everything else is the uniform tool-scan, not a per-host agent).
 4. **Correlate** — `attack-path-stitcher` + `risk-prioritiser` across all validated findings → ranked org roadmap.
-5. **Report** — Transilience PDF over the validated + ranked set + (network) the full host inventory / service+CVE matrix as breadth evidence. COMPLETE only when web coverage is satisfied / every network slice scanned; otherwise `INCOMPLETE_coverage` / `INCOMPLETE_scan`. Scanner-derived CVE findings are flagged distinct from validated deep-dive findings.
+5. **Report** — Transilience PDF over the validated + ranked set + (network) the full host inventory / service+CVE matrix as breadth evidence. Network reports must include exact "what was tested / what was not tested" coverage language, a no-response watchlist, DNS/scope reconciliation, attacker-use / attack-path narrative, remediation roadmap, and safe verification POCs with expected current and fixed results. COMPLETE only when web coverage is satisfied / every network slice scanned; otherwise `INCOMPLETE_coverage` / `INCOMPLETE_scan`. Scanner-derived CVE findings are flagged distinct from validated deep-dive findings.
 
 ## Boundaries
 - Orchestrator only — never run the coordinator loop inline; the coverage/bookkeeping discipline needs the workflow boundary.
@@ -46,6 +46,7 @@ Write the scope file per [`reference/scope-file-format.md`](reference/scope-file
 
 ## References
 - [scope-file-format.md](reference/scope-file-format.md) — scope file schema + worked example
+- [network-exposure-reporting.md](reference/network-exposure-reporting.md) — network-mode coverage wording, exposure matrix, no-response watchlist, and safe verification POCs
 - [coverage-matrix.md](../coordination/reference/coverage-matrix.md) — the canonical attack-class coverage contract (completion gate)
 - [principles.md](../coordination/reference/principles.md) — scope-is-the-surface, reversible active exploitation, real-tools-first, root-cause severity
 - [pentest-report.md](../../formats/transilience-report-style/pentest-report.md) — Transilience report structure + §7.1 root-cause severity

--- a/skills/pentest-engagement/reference/network-exposure-reporting.md
+++ b/skills/pentest-engagement/reference/network-exposure-reporting.md
@@ -1,0 +1,146 @@
+# Network Exposure Reporting
+
+Use this reference when a `pentest-engagement` run is in NETWORK mode or when a web engagement includes an IP/port exposure appendix. The goal is to report externally observed exposure in a way that is precise, reproducible, and useful for attack-path reduction.
+
+## Required Language For Port State
+
+Do not overclaim port state from an external scanner.
+
+Use:
+- `confirmed open` when a TCP connection, SYN/ACK, or service probe confirmed the listener.
+- `no TCP listener accepted a connection during the scan window` when the scan produced no open result.
+- `filtered or no response` when packets were dropped, timed out, geofenced, rate-limited, or source-restricted.
+- `UDP not assessed` or `UDP partially assessed` when non-root runners or time limits prevented UDP coverage.
+
+Avoid:
+- `all other ports are closed`
+- `host is dead`
+- `no risk`
+- `service does not exist`
+
+Reason: a filtered firewall, source allowlist, temporary outage, or geofence can look identical to a closed port from outside. If the runner used TCP connect scanning, state that ports not listed as open did not accept a TCP connection from that source during that window.
+
+## Coverage Accounting
+
+Every report should include a coverage statement with:
+
+| Field | Example |
+|---|---|
+| Target count | `24 supplied IPs` |
+| TCP coverage | `1-65535 attempted for each supplied IP` |
+| Unique target/port combinations | `24 x 65,535 = 1,572,840` |
+| Total attempts | Include duplicates when standard and high-port profiles overlap |
+| UDP coverage | `Not completed; root privileges required` |
+| Tool limitations | `masscan required root`, `naabu unreliable`, `sslscan timed out` |
+| Scope gaps | `SOW states 35 IPs, workbook contains 24 populated IPs` |
+
+When standard and high-port profiles overlap, distinguish unique coverage from total attempts. Example:
+
+```text
+Unique TCP coverage was full-port coverage: 24 x 65,535 target/port combinations.
+Total TCP attempts were higher because selected high ports were attempted in both the standard and high-port passes.
+```
+
+## Required Network Tables
+
+### Confirmed Exposure Matrix
+
+Include every host with at least one confirmed open service:
+
+| IP | Name | Open TCP | Service Notes | Risk Role |
+|---|---|---:|---|---|
+| `192.0.2.10` | `vpn.example.com` | `443,8443` | SSL VPN/admin UI | Remote access |
+| `192.0.2.20` | `patches.example.com` | `443` | endpoint patch portal | Software distribution |
+
+### No-Response Watchlist
+
+Include every supplied IP with no confirmed TCP listener. This is not a "safe list"; it is a drift watchlist.
+
+| IP | Name | Observation | Watch Reason |
+|---|---|---|---|
+| `192.0.2.30` | `firewall` | no TCP listener accepted connection | VPN/UDP/device management may still exist |
+
+### DNS Reconciliation
+
+For hostnames in the scope, compare workbook/source IP to DNS:
+
+| Hostname | Scope IP | DNS Result | Action |
+|---|---|---|---|
+| `patches.example.com` | `192.0.2.20` | `198.51.100.7` | reconcile scope and decide whether DNS IP is in-scope |
+
+DNS mismatches are useful to attackers because they can indicate stale records, migrated services, shadow infrastructure, or incomplete asset inventory.
+
+## Attacker-Use And Attack-Path View
+
+Network reports should include a short "attacker view" section. Rank services by role, not only by CVE count.
+
+High-value roles:
+- Security management: EDR, ePO, SIEM, vulnerability management, MDM.
+- Remote access: VPN, RDP gateways, RemoteApp, TSplus, Citrix, SSTP, SSH jump hosts.
+- Software distribution: endpoint/patch portals, artifact registries, package mirrors.
+- Identity and auth: SSO, LDAP, Kerberos, ADCS, OAuth brokers.
+- Data/API: FHIR, payment, customer portals, object storage, database gateways.
+- Message/control plane: ZeroMQ, RabbitMQ, Kafka, Redis, Celery, job queues.
+- Voice/telecom: SIP/PBX, SBCs, voicemail, call-center systems.
+- Network/device: firewall, CCTV, IoT, OT, SNMP, UPnP, RTSP.
+
+For each role, explain what an attacker could do if they gained valid credentials or exploited a product vulnerability. Keep speculative chains separated from confirmed findings.
+
+Example wording:
+
+```text
+The strongest risk statement is not only that these ports are open. The organization exposes multiple trust-boundary systems: remote access, endpoint management, patch distribution, healthcare APIs, and backend message-plane services. Those systems can be chained through credential theft, product vulnerabilities, misconfiguration, or exposed management functions.
+```
+
+## Safe Verification POCs
+
+Every finding should include a safe verification test and a remediation verification test. These can be commands, scripts, or console checks, but they must avoid destructive behavior unless the rules of engagement explicitly allow it.
+
+Use this format:
+
+| Field | Content |
+|---|---|
+| Finding | `Public ZeroMQ ROUTER socket` |
+| Verification command | `python3 deep-dive/probe_deep.py` |
+| Expected current result | `READY metadata includes Socket-Type=ROUTER` |
+| Remediated result | `external connection times out/refuses, or auth is required` |
+| Boundary | `no message payloads or fuzzing sent` |
+
+Safe examples:
+- `curl -skI` header checks.
+- `nmap -sT -Pn -p PORTS -sV TARGET` service verification.
+- `openssl s_client ... | openssl x509 -noout -dates -subject` certificate validation.
+- `nmap --script sstp-discover -p443 TARGET` protocol support checks.
+- Read-only product version checks from an authenticated admin console when credentials are explicitly supplied.
+
+Avoid unless explicitly authorized:
+- Credential guessing, password spraying, or default credential attempts.
+- Account-disclosure paths that may return live usernames or domain accounts.
+- HTTP `PUT`, `DELETE`, or authenticated state-changing requests against production.
+- DoS, fuzzing, stress testing, malformed-protocol mutation, or exploit payloads.
+- Actions that alter endpoint agents, patch repositories, EDR policy, PBX state, or clinical/healthcare data.
+
+## Remediation Validation
+
+For each remediation, define an observable fixed state:
+
+| Control | Fixed-State Check |
+|---|---|
+| Management service restricted | External untrusted source receives timeout, TCP reset, 403, or identity-aware proxy challenge |
+| CORS allowlist fixed | Untrusted Origin receives no `Access-Control-Allow-Origin` and preflight is denied |
+| Certificate renewed | `notAfter` is in the future and SAN/issuer match documented service ownership |
+| Remote access hardened | MFA enforced, admin version confirms patched release, access logs reviewed |
+| SIP restricted | Only provider/SBC/VPN source ranges reach SIP ports |
+| HTTP methods hardened | Unsupported methods return controlled 403/405; unused methods are absent from Allow |
+
+## Report Completion Gate
+
+A network report is incomplete if any of these are missing:
+- Target and port coverage statement.
+- Open service matrix.
+- No-response watchlist for supplied targets.
+- Tool limitations and UDP caveats.
+- Scope/DNS reconciliation.
+- Remediation roadmap.
+- Safe verification POCs with expected current and expected fixed results.
+- Attack-path or attacker-use narrative for high-value service roles.

--- a/skills/pentest-engagement/reference/scope-file-format.md
+++ b/skills/pentest-engagement/reference/scope-file-format.md
@@ -63,6 +63,7 @@ Network field notes:
 - **Concurrency** — `maxConcurrent` defaults to a prudent value derived from the runner's CPU cores; agents scale with the number of slices (≈ dozens), never with the IP count.
 - **Depth** — `deepen_top` (default 10) selects how many of the highest-value hosts get a full `coordinator-loop` deep-dive + authoritative validation; set `0` for a scan-only run. All other live hosts get the uniform tool scan + per-IP `host.json`.
 - Output is a uniform per-IP tree: `OUTPUT_DIR/hosts/<ip>/{recon,host.json,findings/}` plus a merged `OUTPUT_DIR/recon/inventory/`.
+- Reports must follow `reference/network-exposure-reporting.md`: state the exact TCP/UDP coverage, avoid claiming unlisted ports are permanently closed, include a no-response watchlist for supplied IPs, reconcile DNS/scope drift, and provide safe verification POCs plus expected fixed-state checks for remediation.
 
 ## Invocation
 ```


### PR DESCRIPTION
## Summary
- add network exposure reporting guidance for precise TCP/UDP coverage language, no-response watchlists, DNS reconciliation, and attacker-use narratives
- update port scanning guidance to avoid overclaiming unlisted ports as permanently closed
- update pentest report requirements and workflow prompts to include tested/not-tested sections, remediation roadmaps, and safe verification POCs

## Why
Recent external VAPT work showed that network-mode reports need clearer language around no-response hosts, filtered/closed ambiguity, UDP caveats, and how attackers can use the entire IP/port map for lateral-risk planning. This keeps reports defensible while making them more useful for remediation.

## Validation
- git diff --check
- node --check .claude/workflows/pentest-engagement.js
