### PR TITLE
fix: stop network coverage reporting success while assessing nothing

### DIFF
--- a/.github/workflows/pentest-workflow-tests.yml
+++ b/.github/workflows/pentest-workflow-tests.yml
@@ -49,6 +49,7 @@ jobs:
           python3 tools/test_validate_catalog.py
           python3 tools/test_coverage_gate.py
           python3 tools/test_passive_web_probe.py
+          python3 tools/test_network_coverage_bugs.py
       # Cloud posture catalogues are JSON, and skill_linter.py globs *.md only, so
       # nothing else looks at them. test_tracked_assets.py is the guard for the
       # blanket-*.json trap that has now hidden four separate source files: a

--- a/tools/enumerate_cells.py
+++ b/tools/enumerate_cells.py
@@ -163,14 +163,54 @@ def _recon_hosts(asset_dir: str) -> set:
     return hosts
 
 
+_OPEN_SERVICE_RE = re.compile(r"^\s*(\d{1,5})\s*/\s*(.*)$")
+# A version-looking token inside the free-text service label, e.g. "nginx 1.18.0",
+# "IIS/10.0". Used only to decide version_fingerprinted, never to assert a CVE.
+_VERSION_IN_TEXT_RE = re.compile(r"\d+\.\d+(?:\.\d+)*")
+
+
+def normalize_ports(host: dict) -> list:
+    """Return the host's open listeners as `ports[]` records, from either shape.
+
+    The scan pipeline writes `open_services: ["443/IIS-ASP.NET", ...]`; the schema
+    documented for this loader is `ports: [{port, service, product, version}]`.
+    Every one of the 72 committed host.json files uses the first form and none use
+    the second, so a loader that reads only `ports` returns None for every real
+    host — enumerating zero cells, which the gate then reports as nothing to do.
+    Accept both, and let a host that genuinely has neither fall through to None.
+    """
+    if host.get("ports"):
+        return list(host["ports"])
+    out = []
+    for entry in host.get("open_services") or []:
+        m = _OPEN_SERVICE_RE.match(str(entry))
+        if not m:
+            continue
+        label = m.group(2).strip()
+        out.append({
+            "port": m.group(1),
+            "state": "open",
+            # The label is one free-text blob; it is the only evidence available, so
+            # it serves as both service and product for flag matching. Splitting it
+            # further would be invention.
+            "service": label.lower(),
+            "product": label,
+            "version": m.group(0) if _VERSION_IN_TEXT_RE.search(label) else "",
+        })
+    return out
+
+
 def load_network_host(host_json_path: str) -> dict | None:
     try:
-        host = json.load(open(host_json_path, encoding="utf-8"))
+        with open(host_json_path, encoding="utf-8") as fh:
+            host = json.load(fh)
     except (json.JSONDecodeError, OSError):
         return None
+    ports = normalize_ports(host)
     # Zero-units guard: a dead / no-surface host yields NO cells (not even misconfig).
-    if not host.get("live") or not host.get("ports"):
+    if not host.get("live") or not ports:
         return None
+    host = dict(host, ports=ports)
     ip = host.get("ip") or os.path.basename(os.path.dirname(host_json_path))
     listener_flags: dict = {}
     asset_flags: set = set()

--- a/tools/network_coverage_map.py
+++ b/tools/network_coverage_map.py
@@ -50,10 +50,44 @@ def _verified_regions(*dirs) -> list:
     return sorted(regions)
 
 
-def _raw_scan_ref(host_dir: str) -> str | None:
-    for p in sorted(glob.glob(os.path.join(host_dir, "recon", "*"))):
-        if os.path.isfile(p):
-            return os.path.relpath(p, host_dir)
+# Which attack classes an unauthenticated port/service sweep may close as a genuine
+# negative, and the token its raw output must contain to prove that probe actually
+# ran. FAIL CLOSED: a class absent from this map is NOT sweep-closable, and its cell
+# is left pending for a real probe rather than auto-closed.
+#
+# Before this map, every enumerated cell was written `covered_negative` corroborated
+# by whatever file happened to sit in recon/ — so "a file exists" stood in for "the
+# probe ran and found nothing". A sweep cannot evidence weak TLS ciphers, missing
+# security headers or SMB signing; only a probe that asked those questions can.
+CORROBORATOR_REQUIRED: dict = {
+    # nmap -sV with the vulners/vuln scripts genuinely enumerates service versions
+    # and known-vulnerable components on every open port it fingerprinted.
+    "WEB-A06-COMPONENTS": ("vulners", "<script id=", "service ", "product="),
+}
+
+
+def _scan_files(host_dir: str) -> list:
+    return [p for p in sorted(glob.glob(os.path.join(host_dir, "recon", "*")))
+            if os.path.isfile(p)]
+
+
+def _raw_scan_ref(host_dir: str, tokens=None) -> str | None:
+    """The raw file that corroborates a sweep negative.
+
+    With `tokens`, the file must actually CONTAIN one of them — otherwise the
+    reference is just "some file exists in recon/", which is not evidence that any
+    particular probe was run.
+    """
+    for p in _scan_files(host_dir):
+        if tokens:
+            try:
+                with open(p, encoding="utf-8", errors="replace") as fh:
+                    body = fh.read()
+            except OSError:
+                continue
+            if not any(t in body for t in tokens):
+                continue
+        return os.path.relpath(p, host_dir)
     return None
 
 
@@ -78,17 +112,34 @@ def map_host(host_dir: str, catalog: dict, verified_regions: list, force: bool) 
         return {"host_dir": host_dir, "skipped": "no cells (dead/no-surface host)"}
     by_id = catalog_by_id(catalog)
     ip = next(iter(doc.get("assets", {})), os.path.basename(host_dir.rstrip("/")))
-    scan_ref = _raw_scan_ref(host_dir)
 
     entries_by_class: dict = {}
     tool_eids: list = []
     closed = open_left = 0
+    not_sweep_closable: dict = {}
     for n, cell in enumerate(cells, 1):
         cls = by_id.get(cell["class_id"], {})
         nk = cls.get("negative_kind", "active_probe")
+
+        # An active_probe negative needs proof the probe ran. A class the sweep
+        # cannot answer, or one whose corroborating token is absent from the raw
+        # output, is left PENDING — never closed on the strength of a file existing.
+        if nk == "active_probe":
+            tokens = CORROBORATOR_REQUIRED.get(cell["class_id"])
+            corroborator = _raw_scan_ref(host_dir, tokens) if tokens else None
+            if not corroborator:
+                reason = ("no sweep evidence for this class"
+                          if tokens else "not answerable by an unauthenticated sweep")
+                not_sweep_closable.setdefault(cell["class_id"], {"reason": reason, "cells": 0})
+                not_sweep_closable[cell["class_id"]]["cells"] += 1
+                open_left += 1
+                continue
+        else:
+            corroborator = _raw_scan_ref(host_dir)
+
         e_id = f"SWEEP-{ip}-{n:02d}"
         entry = {"key": cell["scope_key"], "status": "covered_negative", "e_id": e_id, "negative_kind": nk}
-        note = f"swept {cell['class_id']} @ {cell['scope_key']} — no exposure (raw: {scan_ref or 'host.json'})"
+        note = f"swept {cell['class_id']} @ {cell['scope_key']} — no exposure (raw: {corroborator or 'host.json'})"
         if nk == "reachability":
             entry["vantages"] = list(verified_regions)
             if len(verified_regions) >= cls.get("min_vantages", 2):
@@ -98,8 +149,7 @@ def map_host(host_dir: str, catalog: dict, verified_regions: list, force: bool) 
         else:
             closed += 1
         if nk == "active_probe":
-            if scan_ref:
-                entry["corroborator"] = scan_ref
+            entry["corroborator"] = corroborator
             tool_eids.append(e_id)
         _append_experiment(host_dir, e_id, note)
         entries_by_class.setdefault(cell["class_id"], []).append(entry)
@@ -115,11 +165,17 @@ def map_host(host_dir: str, catalog: dict, verified_regions: list, force: bool) 
         tpath = os.path.join(host_dir, "tools", "000_network_sweep.md")
         os.makedirs(os.path.dirname(tpath), exist_ok=True)
         with open(tpath, "w", encoding="utf-8") as f:
-            f.write(f"# network-sweep (deterministic tail)\nRaw scan: {scan_ref or 'host.json'}\n\n")
+            f.write(f"# network-sweep (deterministic tail)\nRaw scan: "
+                    f"{_raw_scan_ref(host_dir) or 'host.json'}\n\n")
             for e in tool_eids:
                 f.write(f"Experiment: {e}\n")
             f.write("\n## Output\nActive-probe host/asset cells corroborated by the raw nmap/nuclei scan output above.\n")
-    return {"host_dir": host_dir, "ip": ip, "cells": len(cells), "closed": closed, "open_reachability": open_left}
+    return {"host_dir": host_dir, "ip": ip, "cells": len(cells), "closed": closed,
+            "open_reachability": open_left,
+            # Reported, never silent: these cells stay pending because a sweep cannot
+            # evidence them. Silent truncation reads as "covered everything".
+            "not_sweep_closable": {k: v["cells"] for k, v in sorted(not_sweep_closable.items())},
+            "not_sweep_closable_reasons": {k: v["reason"] for k, v in sorted(not_sweep_closable.items())}}
 
 
 def main() -> int:

--- a/tools/test_network_coverage_bugs.py
+++ b/tools/test_network_coverage_bugs.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Regression tests for two coverage defects that both produced a FALSE PASS.
+
+Both were invisible in the worst way: the pipeline reported success while
+assessing nothing.
+
+1. `load_network_host()` read only the documented `ports[]` shape. Every one of
+   the 72 committed host.json files uses `open_services: ["443/nginx", ...]` and
+   none uses `ports`, so the loader returned None for every real host, enumerated
+   zero cells, and the gate had nothing to fail on.
+
+2. `network_coverage_map.map_host()` wrote `covered_negative` for EVERY enumerated
+   cell, corroborated by whatever file happened to exist under recon/. "A file
+   exists" stood in for "the probe ran and found nothing", so adding SMB/SNMP/RDP
+   classes to a sweep would have closed them all without a single probe.
+
+Run: python3 tools/test_network_coverage_bugs.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import enumerate_cells as EC          # noqa: E402
+import network_coverage_map as NCM    # noqa: E402
+
+
+def _host(tmp, ip="203.0.113.10", **body):
+    d = os.path.join(tmp, "hosts", ip)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "host.json"), "w", encoding="utf-8") as fh:
+        json.dump({"ip": ip, "live": True, **body}, fh)
+    return d
+
+
+class TestOpenServicesShape(unittest.TestCase):
+    """Bug 1 — the loader must read the shape engagements actually emit."""
+
+    def test_open_services_host_loads(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = _host(t, open_services=["443/IIS-ASP.NET", "8443/ssl-listener"])
+            got = EC.load_network_host(os.path.join(d, "host.json"))
+        self.assertIsNotNone(got, "a host in the real shape must load, not return None")
+        self.assertEqual(len(got["open_listeners"]), 2)
+
+    def test_documented_ports_shape_still_loads(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = _host(t, ports=[{"port": 443, "service": "https", "product": "nginx",
+                                 "version": "1.18.0", "state": "open"}])
+            got = EC.load_network_host(os.path.join(d, "host.json"))
+        self.assertIsNotNone(got)
+        self.assertEqual(len(got["open_listeners"]), 1)
+
+    def test_flags_are_derived_from_the_service_label(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = _host(t, open_services=["443/IIS-ASP.NET", "22/ssh-OpenSSH 8.9"])
+            got = EC.load_network_host(os.path.join(d, "host.json"))
+        flags = got["listener_flags"]
+        https = flags["203.0.113.10:443"]
+        self.assertIn("http_listener", https, "IIS in the label must mark an HTTP listener")
+        self.assertIn("tls_listener", https, "port 443 must mark a TLS listener")
+        self.assertIn("version_fingerprinted", flags["203.0.113.10:22"],
+                      "a version in the label must mark the listener fingerprinted")
+
+    def test_dead_or_surfaceless_host_still_yields_nothing(self):
+        """The zero-units guard must survive the fix — a dead host has no cells."""
+        with tempfile.TemporaryDirectory() as t:
+            d = _host(t, ip="203.0.113.11", open_services=["443/x"])
+            with open(os.path.join(d, "host.json"), "w", encoding="utf-8") as fh:
+                json.dump({"ip": "203.0.113.11", "live": False,
+                           "open_services": ["443/x"]}, fh)
+            self.assertIsNone(EC.load_network_host(os.path.join(d, "host.json")))
+            d2 = _host(t, ip="203.0.113.12", open_services=[])
+            self.assertIsNone(EC.load_network_host(os.path.join(d2, "host.json")))
+
+    def test_malformed_entries_are_skipped_not_crashed(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = _host(t, open_services=["notaport/x", "", "443/ok"])
+            got = EC.load_network_host(os.path.join(d, "host.json"))
+        self.assertEqual(len(got["open_listeners"]), 1, "only the parseable entry counts")
+
+    def test_every_committed_host_json_is_readable(self):
+        """The bug in one line: the loader must work on the real corpus."""
+        import glob
+        repo = os.path.abspath(os.path.join(HERE, ".."))
+        paths = glob.glob(os.path.join(repo, "projects/**/hosts/*/host.json"), recursive=True)
+        if not paths:
+            self.skipTest("no engagement host.json corpus in this checkout")
+        live = [p for p in paths if json.load(open(p, encoding="utf-8")).get("live")
+                and json.load(open(p, encoding="utf-8")).get("open_services")]
+        loaded = [p for p in live if EC.load_network_host(p)]
+        self.assertEqual(len(loaded), len(live),
+                         "every live host with open services must load; "
+                         f"{len(live) - len(loaded)} returned None")
+
+
+class TestSweepCannotAutoClose(unittest.TestCase):
+    """Bug 2 — a sweep may only close what a sweep can actually evidence."""
+
+    def test_sweep_tail_cannot_auto_close_non_http_cells(self):
+        """The headline regression: a class with no corroborating token stays
+        pending, even though a file exists under recon/."""
+        self.assertNotIn("XC-TLS-POSTURE", NCM.CORROBORATOR_REQUIRED,
+                         "a port sweep cannot evidence cipher strength")
+        self.assertNotIn("XC-SECURITY-HEADERS", NCM.CORROBORATOR_REQUIRED,
+                         "a port sweep issues no HTTP request")
+
+    def test_corroborator_requires_a_token_inside_the_file(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = os.path.join(t, "hosts", "203.0.113.20")
+            os.makedirs(os.path.join(d, "recon"), exist_ok=True)
+            with open(os.path.join(d, "recon", "scan.txt"), "w", encoding="utf-8") as fh:
+                fh.write("unrelated output\n")
+            self.assertIsNotNone(NCM._raw_scan_ref(d),
+                                 "without tokens, any file is still a reference")
+            self.assertIsNone(NCM._raw_scan_ref(d, ("vulners",)),
+                              "a file lacking the token must NOT corroborate")
+            with open(os.path.join(d, "recon", "scan.txt"), "w", encoding="utf-8") as fh:
+                fh.write("PORT STATE SERVICE\n443/tcp open  vulners: no findings\n")
+            self.assertIsNotNone(NCM._raw_scan_ref(d, ("vulners",)),
+                                 "a file containing the token must corroborate")
+
+    def test_unclosable_classes_are_reported_not_dropped_silently(self):
+        """A bounded coverage claim must say what it did not cover."""
+        import inspect
+        src = inspect.getsource(NCM.map_host)
+        self.assertIn("not_sweep_closable", src,
+                      "map_host must record the cells it declined to close")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Stacked on `feature/coverage-retest-scope-spine` (#46). Two defects in the network coverage pipeline each produced a false pass in the same way — the gate reported success while nothing was actually measured: the host loader read a JSON shape the scan pipeline never emits, so it enumerated zero cells and the gate had an empty work-list to pass over, and the sweep tail then closed every enumerated cell as a genuine negative on the strength of any file merely existing under `recon/`. Both now fail closed and are covered by nine regression tests wired into CI. Expect coverage ratios on network engagements to drop — they were inflated by cells closed without evidence, and the lower number is the honest one.

## Related Issue

Closes #48

## Changes Made

- `tools/enumerate_cells.py`: add `normalize_ports()` so `load_network_host()` accepts both the `open_services: ["443/<label>"]` shape the scan pipeline actually emits and the documented `ports[]` shape — measured against the committed corpus, 72 host files use the former and zero use the latter, so the loader previously returned None for every real host
- Derive service and product from the free-text port label, which is the only evidence available, and set `version_fingerprinted` only when a version-looking token appears in it, rather than inventing a split the raw output does not support
- Keep the zero-units guard intact across the fix: a host that is not live, or live with no parseable services, still yields no cells, and malformed entries are skipped instead of crashing the load
- `tools/network_coverage_map.py`: replace the "any file under `recon/` corroborates" tail with a `CORROBORATOR_REQUIRED` map from attack class to the token its raw output must contain; a class absent from the map is not sweep-closable and its cell is left pending for a real probe
- Restrict closable classes to version/component enumeration, which the version-detection sweep genuinely performs — a port sweep issues no TLS handshake and no HTTP request, so it cannot evidence cipher strength or missing security headers
- Return the cells the sweep declined to close in `not_sweep_closable` with a per-class reason instead of dropping them silently, so a bounded coverage claim states what it did not cover
- Add `tools/test_network_coverage_bugs.py` (9 tests): the loader is run over the real committed host corpus, corroboration is proven to require the token inside the file rather than the file's existence, and both input shapes, malformed entries and dead hosts are asserted
- Wire the new test file into `.github/workflows/pentest-workflow-tests.yml` alongside the existing coverage-gate and catalog checks

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New skill or agent
- [ ] Enhancement to existing skill/agent
- [ ] Documentation update
- [ ] CI/CD or infrastructure
- [ ] Refactoring (no functional change)
- [ ] Other: fix

## Testing

- [ ] Tested skill/agent in Claude Code session
- [ ] Tested against vulnerable application (DVWA, WebGoat, Juice Shop, etc.)
- [ ] Verified no false positives
- [x] Ran existing tests
- [ ] Manual review only (documentation/config changes)

**Test details:**

**Content guard:** `/content-guard` — **CLEAN**
- changed-scope: 4 item(s) scanned (every blob this branch introduces, plus worktree, index and untracked)
- whole-tree backstop: 1204 item(s) scanned
- client-name lane: active
- tree digest: `cd2eb394f81e6ab7`


## Checklist

- [x] My code follows the contribution guidelines
- [x] Commits use conventional format: `type: description`
- [ ] I've updated documentation where needed
- [ ] New skills include `SKILL.md` and `reference/` directory
- [x] No secrets, credentials, or unauthorized target information included
- [x] This PR links to an issue with `Closes #N`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
