### PR TITLE
feat: scope retest by severity, declare onsite sites[], and make a blocked cycle legible

### DIFF
--- a/.claude/workflows/pentest-engagement.js
+++ b/.claude/workflows/pentest-engagement.js
@@ -298,7 +298,19 @@ async function finalizeEngagement(opts) {
     certin_xlsx: wantCertin ? (r.certin_xlsx || null) : null,
     certin_needs_manual: wantCertin ? (r.certin_needs_manual || []) : [],
     summary: { engagement_status: engagementStatus, agents: agentCount != null ? agentCount : 'unavailable', findings: Number(r.findings) || 0, severity_counts: r.severity_counts || {}, tokens: 'unavailable (no runtime token counter)', cost: 'unavailable (no runtime token counter)', elapsed: r.elapsed || 'unavailable', tools_used_count: Number(r.tools_used_count) || 0, source_ips_count: Number(r.source_ips_count) || 0, reconciliation_gaps: r.reconciliation_gaps || [], coverage_ratio: r.coverage_ratio != null ? r.coverage_ratio : null, coverage_untested: coverageUntested, summary_path: r.summary_path || `${engagementDir}/reports/summary.md`, protected_zip: wantProtect ? (r.protected_zip || null) : null, deliverable_password: wantProtect ? (r.deliverable_password || null) : null },
+    // Slack stays gated on a clean gate, deliberately: a completion ping must signal
+    // a finished engagement, not a status update for a stalled one.
     slack_offer: gate.ok,
+    // The blocked state was previously invisible in the RESULT too — a non-OK gate
+    // returned no reason and no next step, so a stalled cycle looked like a quiet
+    // one. These make it legible to the operator without turning it into a ping.
+    status_signal: gate.ok ? 'GREEN' : (r.report_data_ok ? 'AMBER' : 'RED'),
+    blocked_reason: gate.ok ? null : (gate.blocked_reason || engagementStatus),
+    // What is still owed, so a blocked cycle names its own unblock instead of
+    // leaving the operator to diff the coverage matrix by hand.
+    outstanding_prerequisites: Array.isArray(r.client_input_requests) && r.client_input_requests.length
+      ? r.client_input_requests
+      : (coverageUntested > 0 ? [`${coverageUntested} attack-class cell(s) untested — see reports/coverage-matrix.json`] : []),
   }
 }
 

--- a/.claude/workflows/retest-engagement.js
+++ b/.claude/workflows/retest-engagement.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'retest-engagement',
   description: 'Retest a PRIOR report\'s findings against the current target: ingest the baseline findings (tools/report_ingest.py), blind-re-validate EACH finding against the live target, assign a standardized verdict from a fixed vocabulary (Closed / Open / Partially-Remediated / Risk-Accepted / Needs-Live-Retest / False-Positive), then produce a canonical retest-status deliverable (baseline-vs-current table + status rollup) via tools/retest_status_build.py -> generate_report.py. Includes a controls-disabled/_SSL_Disabled_ test-build detector that flags affected verdicts as production-re-verification-required, and a multi-engagement portfolio roll-up mode. Deterministic bytes are owned by tools (report_ingest, retest_status_build, generate_report) — no LLM authors the final JSON.',
-  whenToUse: 'Retest a prior engagement\'s report against the current target (a follow-up / revalidation assessment), OR roll up several retests into one portfolio matrix. args: {prior_report (a finished report file/dir to ingest) OR baseline (a findings JSON array), target (what to retest against), output_dir? (default projects/pentest/<date>_retest), votes? (adversarial quorum, default 2), build_markers? (filenames/flags for the controls-disabled detector), controls_disabled? (bool), portfolio? ([ ...retest-status docs ] -> roll-up mode)}. One of prior_report/baseline (or portfolio) is required.',
+  whenToUse: 'Retest a prior engagement\'s report against the current target (a follow-up / revalidation assessment), OR roll up several retests into one portfolio matrix. args: {prior_report (a finished report file/dir to ingest) OR baseline (a findings JSON array), target (what to retest against), output_dir? (default projects/pentest/<date>_retest), votes? (adversarial quorum, default 2), min_severity? (retest only findings at or above this band; default 'High' because a re-validation is normally contracted for critical/high — pass 'Low'/'Info'/'all' to widen), build_markers? (filenames/flags for the controls-disabled detector), controls_disabled? (bool), portfolio? ([ ...retest-status docs ] -> roll-up mode)}. One of prior_report/baseline (or portfolio) is required.',
   phases: [
     { title: 'Ingest', detail: 'tools/report_ingest.py parses the prior report into baseline findings' },
     { title: 'Retest', detail: 'per baseline finding: a blind retester probes the CURRENT target -> a fixed-vocabulary verdict + note + evidence' },
@@ -71,6 +71,30 @@ if (!baseline) {
   if (ing && ing.warnings && ing.warnings.length) log(`report_ingest warnings: ${JSON.stringify(ing.warnings.slice(0, 8))}`)
 }
 if (!baseline.length) return { ok: false, status: 'BLOCKED', blocked_reason: 'baseline ingest produced 0 findings' }
+
+// Severity scoping. A re-validation is normally contracted to confirm that CRITICAL
+// and HIGH findings were remediated, so retesting every Low and Info by default
+// spends the budget on the items nobody asked about. Opt in to a wider sweep with
+// min_severity: 'Low' / 'Info', or 'all'.
+const SEV_RANK = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4, Informational: 4 }
+const minSeverity = input.min_severity == null ? 'High' : String(input.min_severity)
+const severityCutoff = minSeverity.toLowerCase() === 'all' ? 99 : SEV_RANK[minSeverity]
+if (severityCutoff === undefined) {
+  return { ok: false, status: 'BLOCKED', blocked_reason: `min_severity ${JSON.stringify(input.min_severity)} is not one of Critical/High/Medium/Low/Info/all` }
+}
+const baselineAll = baseline
+// Rank an unknown/absent severity as most-urgent: dropping a finding because its
+// severity did not parse would silently narrow the retest.
+const inScope = baselineAll.filter((f) => (SEV_RANK[f && f.severity] ?? 0) <= severityCutoff)
+const outOfScope = baselineAll.length - inScope.length
+if (!inScope.length) {
+  return { ok: false, status: 'BLOCKED', blocked_reason: `no baseline finding is ${minSeverity} or above (${baselineAll.length} below the cutoff) — pass min_severity to widen` }
+}
+baseline = inScope
+// Never silent: the report has to be able to say what was NOT retested, or a
+// partial sweep reads as a full one.
+const severityScope = { min_severity: minSeverity, retested: inScope.length, deferred: outOfScope, baseline_total: baselineAll.length }
+if (outOfScope) log(`Severity scope ${minSeverity}+: retesting ${inScope.length} of ${baselineAll.length}; ${outOfScope} below the cutoff are carried as not-retested.`)
 log(`Retesting ${baseline.length} baseline finding(s) against ${TARGET} (${VOTES} vote(s) each).`)
 
 // --- Phase Retest ----------------------------------------------------------
@@ -130,7 +154,7 @@ log(`Retest verdicts: ${JSON.stringify(rollupCounts)}`)
 phase('Report')
 const baselinePath2 = `${OUTPUT_DIR}/input/baseline.json`
 const verdictsPath = `${OUTPUT_DIR}/input/verdicts.json`
-const metaObj = { target: TARGET, controls_disabled: !!input.controls_disabled, build_markers: input.build_markers || [], engagement: input.engagement || {} }
+const metaObj = { target: TARGET, controls_disabled: !!input.controls_disabled, build_markers: input.build_markers || [], engagement: input.engagement || {}, severity_scope: severityScope }
 const genCmd = `python3 skills/transilience-report-style/reference/generate_report.py ${OUTPUT_DIR}/reports/report_data.json -o ${OUTPUT_DIR}/reports/Retest-Report.pdf --assets formats/transilience-report-style --theme light`
 const finalize = await agent(
   `ROLE: RETEST FINALIZE RUNNER (deterministic tool-runner, no judgment). cwd is repo root.\n` +
@@ -149,6 +173,7 @@ return {
   ok, status: ok ? 'COMPLETE' : 'BLOCKED',
   blocked_reason: ok ? null : (!finalize || !finalize.build_ok ? 'retest_status_build failed' : finalize.lint_ok === false ? 'report_data lint failed' : 'render failed'),
   mode: 'single', target: TARGET, baseline_count: baseline.length,
+  severity_scope: severityScope,
   rollup: rollupCounts, report: finalize && finalize.report_path,
   deliverable_zip: `${OUTPUT_DIR}/retest_deliverable.zip`,
 }

--- a/skills/pentest-engagement/reference/scope-file-format.md
+++ b/skills/pentest-engagement/reference/scope-file-format.md
@@ -23,6 +23,11 @@ The `pentest-engagement` workflow ingests a scope file describing the engagement
     "prohibitions": ["no DoS", "no brute force", "no destructive/irreversible writes", "no out-of-scope tenants"]
   },
   "business_tier": "unknown",                       // default tier for assets without one
+  "onsite": false,                                   // true when any in-scope activity needs a person on site
+  "sites": [                                         // physical locations; required when onsite is true
+    { "label": "HQ", "city": "Riyadh", "window": "2026-03-02..2026-03-06",
+      "activities": ["wireless"], "notes": "5 SSIDs; escort required" }
+  ],
   "certin_export": false,                            // when true, ALSO emit the CERT-In Audit Metadata deliverable (see below)
   "certin": {                                        // optional admin config for the CERT-In export; all keys optional
     "ambak_no": "AUD2026...",
@@ -42,6 +47,7 @@ The `pentest-engagement` workflow ingests a scope file describing the engagement
 - **business_tier** feeds the risk-prioritiser (`feasibility × CVSS × business_impact × exposure`).
 - **roe.reversible_writes**: when true, the engine may create-then-delete a resource in the tester's **own** org/tenant to prove a write-dependent finding (e.g. connector `base_url` SSRF, mass-assignment). Always non-destructive; always cleaned up. Set false for strictly read-only engagements.
 - **creds_env**: a *missing* credential is never a global block — the unauthenticated surface is always tested. List every key/login the engagement may use.
+- **onsite / sites[]**: some work cannot be done remotely — wireless testing needs an antenna in the building, physical red-team entry needs a person at the door, and a device fleet may only be reachable from inside a site. `sites[]` names each location, the window it is available, and which activities happen there, so a remote-only run cannot silently report those classes as assessed. A site with no window is a prerequisite the client still owes; treat it as a blocker for that site's activities, not for the engagement. Keep this to labels, cities and windows — a street address is personal/premises data and belongs in the engagement directory, not the scope schema.
 - **certin_export**: set `true` for a CERT-In-empanelled audit. At completion the engine ALSO produces the CERT-In Audit Metadata deliverable — `reports/certin-audit-metadata.json` + `reports/CERT-In-Audit-Metadata.xlsx` — **alongside** the normal report (never replacing it; CERT-In requires the report to accompany the metadata). This is **non-blocking**: it never affects the engagement completion gate. Administrative fields the findings can't supply come from the inline **certin** block (materialized to `<eng>/input/certin.json`) or a `certin.json` the operator drops in `input/`; anything absent is emitted as a `<FILL: field>` placeholder. Run `.claude/workflows/certin-export.js` afterward to have AI fill the judgment fields (audit-type, sector, standards, per-finding Attributing Factor).
 
 ## Markdown form

--- a/tools/retest_status_build.py
+++ b/tools/retest_status_build.py
@@ -64,6 +64,11 @@ STATUS_PRIORITY = {"Open": 0, "Partially-Remediated": 1, "Needs-Live-Retest": 2,
 
 # Still-actionable statuses carried into findings[] (the report body).
 ACTIONABLE = frozenset({"Open", "Partially-Remediated", "Needs-Live-Retest"})
+# Statuses that mean "this no longer needs remediation work". Risk-Accepted counts:
+# the client owns it deliberately, which is a decision, not an outstanding fix.
+CLOSED_STATUSES = frozenset({"Closed", "Risk-Accepted", "False-Positive"})
+# The severities a re-validation is normally contracted to confirm.
+CRITICAL_HIGH = ("Critical", "High")
 
 # Per-status colour hint the generator can render (metric boxes read `color`; the
 # map is also emitted top-level so a caller can colour the status column).
@@ -210,6 +215,41 @@ def _summary_paragraph(rollup, total):
     return f"{total} baseline finding(s) retested: {', '.join(parts) if parts else 'none'}."
 
 
+def _severity_cross_tab(rows):
+    """Status x severity, plus the closure rate for Critical/High.
+
+    The status rollup alone answers "how many are closed" but not "were the ones
+    that mattered closed". Re-validation is normally contracted for critical and
+    high findings specifically, so that number has to be readable without the
+    reader cross-referencing two tables by hand.
+    """
+    sevs = [s for s in B.SEVERITY_ORDER if any(r["severity"] == s for r in rows)]
+    header = ["Retest Status"] + sevs + ["Total"]
+    table_rows = []
+    for st in STATUS_ORDER:
+        counts = [sum(1 for r in rows if r["status"] == st and r["severity"] == s) for s in sevs]
+        if not any(counts):
+            continue
+        table_rows.append([st] + [str(c) for c in counts] + [str(sum(counts))])
+    totals = [sum(1 for r in rows if r["severity"] == s) for s in sevs]
+    table_rows.append(["Total"] + [str(c) for c in totals] + [str(len(rows))])
+
+    high = [r for r in rows if r["severity"] in CRITICAL_HIGH]
+    closed = sum(1 for r in high if r["status"] in CLOSED_STATUSES)
+    para = (f"Critical/High closed: {closed} of {len(high)}." if high
+            else "No Critical or High findings in the baseline.")
+    if high and closed < len(high):
+        para += (f" {len(high) - closed} remain unresolved — these are the items a "
+                 "re-validation is normally contracted to confirm.")
+    n = max(2, len(header))
+    return {
+        "title": "Closure by Severity",
+        "paragraphs": [para],
+        "table": {"header": header, "rows": table_rows,
+                  "widths": [round(1.0 / n, 4)] * n},
+    }
+
+
 def build_retest(baseline, verdicts, meta=None):
     """Assemble a canonical retest-status report_data from baseline + verdicts.
 
@@ -268,6 +308,7 @@ def build_retest(baseline, verdicts, meta=None):
         "paragraphs": [_summary_paragraph(rollup, len(baseline))],
         "table": {"header": ["Retest Status", "Count"], "rows": summary_rows, "widths": [0.7, 0.3]},
     }
+    sev_section = _severity_cross_tab(rows)
     bvc_section = {
         "title": "Baseline vs Current",
         "paragraphs": ["Every prior-report finding with its retest verdict. Closed, "
@@ -286,7 +327,7 @@ def build_retest(baseline, verdicts, meta=None):
         "engagement": meta.get("engagement", {}),
         "findings": findings,
         "metrics": metrics,
-        "sections": [summary_section, bvc_section],
+        "sections": [summary_section, sev_section, bvc_section],
         "retest_status_colors": dict(STATUS_COLORS),
         "retest_rollup": rollup,
         "retest_engagement_label": _label_from_meta(meta),

--- a/tools/test_retest_status_build.py
+++ b/tools/test_retest_status_build.py
@@ -236,6 +236,35 @@ def test_cli_portfolio_exit0():
         assert port["retest_rollup"]["Open"] == 2
 
 
+def test_severity_cross_tab_reports_critical_high_closure():
+    """The status rollup answers "how many closed", not "were the ones that
+    mattered closed" — which is what a re-validation is contracted to confirm."""
+    base = [{"id": "F-001", "title": "RCE", "severity": "Critical"},
+            {"id": "F-002", "title": "SQLi", "severity": "High"},
+            {"id": "F-003", "title": "XSS", "severity": "High"},
+            {"id": "F-004", "title": "Header", "severity": "Low"}]
+    verd = {"F-001": {"status": "Closed"}, "F-002": {"status": "Open"},
+            "F-003": {"status": "Risk-Accepted"}, "F-004": {"status": "Closed"}}
+    doc = R.build_retest(base, verd, {})
+    sec = [s for s in doc["sections"] if s["title"] == "Closure by Severity"]
+    assert sec, "the severity cross-tab section must be emitted"
+    sec = sec[0]
+    # Risk-Accepted counts as closed: the client owns it deliberately.
+    assert "Critical/High closed: 2 of 3" in sec["paragraphs"][0], sec["paragraphs"][0]
+    assert "1 remain unresolved" in sec["paragraphs"][0]
+    assert sec["table"]["header"][0] == "Retest Status"
+    assert "Critical" in sec["table"]["header"] and "High" in sec["table"]["header"]
+    totals = [r for r in sec["table"]["rows"] if r[0] == "Total"][0]
+    assert totals[-1] == "4", totals
+
+
+def test_severity_cross_tab_handles_a_baseline_with_no_high_findings():
+    doc = R.build_retest([{"id": "F-1", "title": "x", "severity": "Low"}],
+                         {"F-1": {"status": "Closed"}}, {})
+    sec = [s for s in doc["sections"] if s["title"] == "Closure by Severity"][0]
+    assert "No Critical or High findings" in sec["paragraphs"][0]
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
## Summary

Three spine items. A re-validation exists to answer whether the critical and high findings were remediated, but the retest workflow piped every baseline finding through blind retesters regardless of band and the status rollup answered only "how many are closed" — so the number that matters was not readable without cross-referencing two tables by hand, and the budget went on Lows nobody asked about. The scope schema had no concept of a physical site, so classes that need someone in the building (wireless, physical entry, an internally-reachable device fleet) could be reported as assessed by a remote-only run; and a non-OK completion gate returned no reason and no next step, so a stalled cycle looked like a quiet one.

## Related Issue

Closes #50

## Changes Made

- Retest is scoped by severity: min_severity defaults to High, widened with Low/Info/all. An unknown or absent severity ranks as most-urgent, so a finding is never dropped because its band failed to parse; an unrecognized min_severity, or a cutoff that matches nothing, blocks with a reason rather than silently retesting zero findings.
- The scope is carried into the report meta and the workflow return as severity_scope {min_severity, retested, deferred, baseline_total} — a partial sweep that does not declare itself partial reads as a full one.
- New "Closure by Severity" section in the retest deliverable: a status x severity cross-tab plus the sentence a reader looks for first — "Critical/High closed: N of M", and how many remain. Risk-Accepted counts as closed, because a deliberately owned risk is a decision rather than an outstanding fix.
- Scope schema gains onsite: bool and sites[] {label, city, window, activities, notes}. A site with no window is a prerequisite the client still owes: a blocker for that site's activities, not for the engagement. Labels, cities and windows only — a street address is premises data and belongs in the engagement directory, not a schema that lives in a public repo.
- The engagement finalize return now carries status_signal (GREEN/AMBER/RED), blocked_reason from the gate, and outstanding_prerequisites — the recorded client-input requests, else the untested-cell count pointing at the coverage matrix — so a blocked cycle names its own unblock.
- slack_offer stays gated on a clean gate, now with the reasoning recorded in place: making a blocked state visible belongs in the return value, while making it ping is the noise the standing preference against partial-completion notifications exists to prevent.
- Two tests added to the retest status builder suite (12/12): the cross-tab reports Critical/High closure with Risk-Accepted counted as closed, and a baseline with no Critical or High findings says so rather than dividing by zero.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New skill or agent
- [x] Enhancement to existing skill/agent
- [ ] Documentation update
- [ ] CI/CD or infrastructure
- [ ] Refactoring (no functional change)
- [ ] Other: feat

## Testing

- [ ] Tested skill/agent in Claude Code session
- [ ] Tested against vulnerable application (DVWA, WebGoat, Juice Shop, etc.)
- [ ] Verified no false positives
- [x] Ran existing tests
- [ ] Manual review only (documentation/config changes)

**Test details:**

**Content guard:** `/content-guard` — **CLEAN**
- changed-scope: 5 item(s) scanned (every blob this branch introduces, plus worktree, index and untracked)
- whole-tree backstop: 1204 item(s) scanned
- client-name lane: active
- tree digest: `602f9a8d1b0b9307`


## Checklist

- [x] My code follows the contribution guidelines
- [x] Commits use conventional format: `type: description`
- [ ] I've updated documentation where needed
- [ ] New skills include `SKILL.md` and `reference/` directory
- [x] No secrets, credentials, or unauthorized target information included
- [x] This PR links to an issue with `Closes #N`

## Skill / agent checklist

- [ ] `python3 scripts/skill_linter.py` runs clean (or rationale below).
- [ ] No new challenge-specific identifiers outside `skills/hackthebox/`.
- [ ] `SKILL.md` ≤ 150 lines; `reference/*.md` ≤ 200 lines.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
