### PR TITLE
fix: pin one OWASP LLM edition — the skill asserted two at once

### DIFF
--- a/.github/workflows/pentest-workflow-tests.yml
+++ b/.github/workflows/pentest-workflow-tests.yml
@@ -15,6 +15,7 @@ on:
       # change, so the validator is wired up and still never runs on the PR that
       # needs it — a check that exists but does not execute.
       - 'skills/cloud-containers/**'
+      - 'skills/ai-threat-testing/**'
       - '.github/workflows/pentest-workflow-tests.yml'
   push:
     branches: [main]
@@ -25,6 +26,7 @@ on:
       - 'skills/coordination/reference/coverage-matrix.md'
       - 'skills/mobile-security/**'
       - 'skills/cloud-containers/**'
+      - 'skills/ai-threat-testing/**'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'   # weekly live e2e (Mon 06:00 UTC)
@@ -65,6 +67,7 @@ jobs:
           python3 tools/posture/catalog_validate.py --all
           python3 tools/posture/test_catalog_validate.py
           python3 tools/test_tracked_assets.py
+          python3 tools/test_llm_numbering.py
       # A vantage counts only when an egress echo proved it. Guards the hole where
       # register_source_ip.py wrote verified:true unconditionally, so two --dry-run
       # provisions closed a min_vantages:2 reachability cell with zero packets sent.

--- a/skills/ai-threat-testing/SKILL.md
+++ b/skills/ai-threat-testing/SKILL.md
@@ -16,22 +16,30 @@ Test LLM applications for OWASP LLM Top 10 vulnerabilities using 10 specialized 
 4. Professional report with PoCs generated
 ```
 
-## Primary Agents
+## Coverage — OWASP LLM Top 10, 2025 edition
 
-Each agent targets one OWASP LLM vulnerability:
+**Which file addresses which category is decided by
+[`reference/catalog/llm-top10-2025.json`](reference/catalog/llm-top10-2025.json), not by the
+filename.** The `llmNN-` prefixes on disk predate the 2025 renumbering and no longer match; the
+content is correct, the labels were not. Cite an id only with its edition (`LLM06:2025`), because a
+bare `LLM06` means two different categories depending on which edition the reader assumes.
 
-1. **Prompt Injection** (LLM01): Direct/indirect injection, system prompt extraction
-2. **Output Handling** (LLM02): Code/XSS injection, unsafe deserialization
-3. **Training Poisoning** (LLM03): Membership inference, backdoors, data extraction
-4. **Resource Exhaustion** (LLM04): Token flooding, DoS, cost impact
-5. **Supply Chain** (LLM05): Dependency scanning, plugin security
-6. **Excessive Agency** (LLM06): Privilege escalation, unauthorized actions
-7. **Model Extraction** (LLM07): Query-based theft, data reconstruction
-8. **Vector Poisoning** (LLM08): RAG injection, retrieval manipulation
-9. **Overreliance** (LLM09): Hallucination testing, confidence manipulation
-10. **Logging Bypass** (LLM10): Monitoring evasion, forensic gaps
+| Category | Attack surface |
+|---|---|
+| `LLM01:2025` Prompt Injection | Direct and indirect injection, instruction override, filter evasion |
+| `LLM02:2025` Sensitive Information Disclosure | Training-data and cross-tenant RAG leakage, canary verification |
+| `LLM03:2025` Supply Chain | Dependency CVEs, model provenance, malicious serialized models |
+| `LLM04:2025` Data and Model Poisoning | Backdoor triggers, membership inference, behavioural anomalies |
+| `LLM05:2025` Improper Output Handling | Code/XSS injection downstream, unsafe deserialization |
+| `LLM06:2025` Excessive Agency | Tool/plugin abuse, privilege escalation, unauthorised actions — the category that matters for **agents** rather than chatbots |
+| `LLM07:2025` System Prompt Leakage | **Gap — no playbook yet.** See the catalogue: what the prompt *contains* is a separate finding from whether it can be extracted |
+| `LLM08:2025` Vector and Embedding Weaknesses | RAG injection, retrieval manipulation, embedding inversion |
+| `LLM09:2025` Misinformation | Hallucination and confidence manipulation where output is relied upon |
+| `LLM10:2025` Unbounded Consumption | Token flooding, cost impact, and **model extraction/theft** (2025 treats extraction-by-query as a consumption problem) |
 
-See `reference/llm0X-*.md` for attack playbooks.
+Two classes are testable but are **not** OWASP categories, so they carry local `TX-` ids rather than
+an invented `LLMnn`: monitoring evasion / forensic gaps, and adversarial perturbation of non-text
+input. `tools/test_llm_numbering.py` enforces that separation.
 
 ## Workflows
 
@@ -46,7 +54,7 @@ See `reference/llm0X-*.md` for attack playbooks.
 
 **Focused Testing** (1-3 hours):
 ```
-- [ ] Select vulnerability (LLM01-10)
+- [ ] Select a category from the catalogue (LLM01:2025 .. LLM10:2025, or a TX- local class)
 - [ ] Deploy agent
 - [ ] Execute techniques
 - [ ] Document findings

--- a/skills/ai-threat-testing/reference/adversarial-pixel-attacks.md
+++ b/skills/ai-threat-testing/reference/adversarial-pixel-attacks.md
@@ -1,5 +1,7 @@
 # Adversarial Pixel Attacks (L0-Bounded)
 
+> Category **`TX-LLM-ADVERSARIAL-INPUT`** Adversarial perturbation of non-text model input. Authoritative mapping: [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
+
 ## When this applies
 
 - An HTTP endpoint grants access / reveals a flag / changes state based on classifier output (image, audio, sensor reading). This is an **ML-as-Authorization** boundary — equivalent to authentication and rated CVSS ≈ 7.5 when bypassed.

--- a/skills/ai-threat-testing/reference/agentic-tool-hijacking.md
+++ b/skills/ai-threat-testing/reference/agentic-tool-hijacking.md
@@ -1,5 +1,7 @@
 # Agentic AI Tool-Call Hijacking
 
+> Category **`LLM06:2025`** Excessive Agency. Authoritative mapping: [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
+
 ## When this applies
 
 - An app's UI flows user input through an LLM that holds tools (`set_X`, `update_Y`, `grant_Z`) which mutate server-side state.

--- a/skills/ai-threat-testing/reference/catalog/llm-top10-2025.json
+++ b/skills/ai-threat-testing/reference/catalog/llm-top10-2025.json
@@ -1,0 +1,119 @@
+{
+  "meta": {
+    "catalog_id": "owasp-llm-top10",
+    "framework": "OWASP Top 10 for Large Language Model Applications",
+    "framework_version": "2025",
+    "source_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "licence_note": "OWASP material is CC BY-SA. Category ids and titles are cited as identifiers; every procedure in this skill is our own writing. Nothing is reproduced from the OWASP text, because share-alike would otherwise infect the file carrying it.",
+    "why_this_file": "The skill carried two incompatible numbering schemes at once. reference/ used LLM06=Excessive Agency, LLM07=Model Extraction, LLM08=Vector Poisoning, LLM10=Insufficient Logging; reference/scenarios/llm/ used the OWASP 2023 order (LLM06=Sensitive Information Disclosure, LLM07=Insecure Plugin Design, LLM08=Excessive Agency). A deliverable citing 'OWASP LLM Top 10' therefore contradicted itself, and 'Insufficient Logging & Monitoring' is not an OWASP LLM category in ANY edition. Filenames are left alone deliberately — renaming would break inbound links and the files are correct content under the wrong label. THIS catalogue is the single source of truth for which category a file addresses; the filename is only a filename.",
+    "local_namespace": "TX-",
+    "local_namespace_note": "A genuinely testable class that OWASP does not carry as a Top 10 category gets a TX- id. It is never given an LLMnn number, because an invented OWASP id is what made the original claim false."
+  },
+
+  "categories": [
+    {
+      "id": "LLM01:2025",
+      "title": "Prompt Injection",
+      "covered_by": [
+        "reference/llm01-prompt-injection.md",
+        "reference/scenarios/llm/llm01-prompt-injection-direct.md",
+        "reference/scenarios/llm/llm01-prompt-injection-indirect.md"
+      ],
+      "atlas_xref": ["AML.T0051"],
+      "note": "The one category whose filename already matched its id in both trees."
+    },
+    {
+      "id": "LLM02:2025",
+      "title": "Sensitive Information Disclosure",
+      "covered_by": ["reference/scenarios/llm/llm06-sensitive-info-disclosure.md"],
+      "note": "Filed as LLM06 on disk, which was the 2023 id. Content is correct for this category."
+    },
+    {
+      "id": "LLM03:2025",
+      "title": "Supply Chain",
+      "covered_by": [
+        "reference/llm05-supply-chain.md",
+        "reference/scenarios/llm/llm05-supply-chain-vulnerabilities.md",
+        "reference/malicious-keras-model-triage.md"
+      ],
+      "note": "Was LLM05 in 2023."
+    },
+    {
+      "id": "LLM04:2025",
+      "title": "Data and Model Poisoning",
+      "covered_by": [
+        "reference/llm03-training-poisoning.md",
+        "reference/scenarios/llm/llm03-training-data-poisoning.md"
+      ],
+      "note": "2023 called this Training Data Poisoning and numbered it LLM03; 2025 widens it to model poisoning."
+    },
+    {
+      "id": "LLM05:2025",
+      "title": "Improper Output Handling",
+      "covered_by": [
+        "reference/llm02-insecure-output.md",
+        "reference/scenarios/llm/llm02-insecure-output-handling.md"
+      ],
+      "note": "Was LLM02 in 2023."
+    },
+    {
+      "id": "LLM06:2025",
+      "title": "Excessive Agency",
+      "covered_by": [
+        "reference/llm06-excessive-agency.md",
+        "reference/scenarios/llm/llm08-excessive-agency.md",
+        "reference/scenarios/llm/llm07-insecure-plugin-design.md",
+        "reference/agentic-tool-hijacking.md"
+      ],
+      "note": "2023 carried Insecure Plugin Design as a separate LLM07; 2025 folds plugin/tool design into Excessive Agency, so both files land here. This is the category that matters most for AI agents rather than chatbots."
+    },
+    {
+      "id": "LLM07:2025",
+      "title": "System Prompt Leakage",
+      "covered_by": [],
+      "gap": "No dedicated file. System-prompt extraction is touched inside reference/llm01-prompt-injection.md as an injection objective, but 2025 makes it a category in its own right: what the system prompt CONTAINS that should not be there (credentials, connection strings, authorisation logic) is a different finding from whether it can be extracted. Write it before claiming coverage of this category.",
+      "atlas_xref": ["AML.T0051"]
+    },
+    {
+      "id": "LLM08:2025",
+      "title": "Vector and Embedding Weaknesses",
+      "covered_by": [
+        "reference/llm08-vector-poisoning.md",
+        "reference/hopfield-recovery.md",
+        "reference/gradient-leakage-attacks.md"
+      ],
+      "note": "Not an OWASP category at all in 2023; the file was numbered LLM08 against the 2025 list while its neighbours were numbered against 2023, which is how the two schemes ended up interleaved in one directory."
+    },
+    {
+      "id": "LLM09:2025",
+      "title": "Misinformation",
+      "covered_by": ["reference/llm09-overreliance.md"],
+      "note": "2023 framed this as Overreliance — the human-factors side. 2025 reframes it around the model's output being wrong and relied upon."
+    },
+    {
+      "id": "LLM10:2025",
+      "title": "Unbounded Consumption",
+      "covered_by": [
+        "reference/llm04-resource-exhaustion.md",
+        "reference/scenarios/llm/llm04-denial-of-service.md",
+        "reference/llm07-model-extraction.md"
+      ],
+      "note": "Two 2023 categories collapse here: Model Denial of Service (2023 LLM04) and Model Theft (2023 LLM10). 2025 treats extraction-by-query as a consumption problem, which is why model-extraction content belongs in this category rather than under an invented LLM07."
+    }
+  ],
+
+  "local_classes": [
+    {
+      "id": "TX-LLM-LOG-EVASION",
+      "title": "Monitoring evasion and forensic gaps in an LLM application",
+      "covered_by": ["reference/llm10-logging-bypass.md"],
+      "rationale": "Real and testable — whether prompts, tool calls and refusals are logged in a way an investigation could use, and whether an attacker can suppress that trail. But OWASP has never carried it as an LLM Top 10 category, in 2023 or 2025. It was labelled LLM10, which is Model Theft in 2023 and Unbounded Consumption in 2025, so the label asserted conformance to something that does not exist. Kept as a local class rather than deleted: the content is good, only the id was false."
+    },
+    {
+      "id": "TX-LLM-ADVERSARIAL-INPUT",
+      "title": "Adversarial perturbation of non-text model input",
+      "covered_by": ["reference/adversarial-pixel-attacks.md"],
+      "rationale": "Applies to multimodal and vision models rather than to LLM text applications, so it sits outside the LLM Top 10 scope entirely. Recorded here so it is not mistaken for an uncovered OWASP category."
+    }
+  ]
+}

--- a/skills/ai-threat-testing/reference/gradient-leakage-attacks.md
+++ b/skills/ai-threat-testing/reference/gradient-leakage-attacks.md
@@ -1,5 +1,7 @@
 # Gradient-Leakage Attacks (DLG / iDLG / Inverting Gradients)
 
+> Category **`LLM08:2025`** Vector and Embedding Weaknesses. Authoritative mapping: [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
+
 ## When this applies
 
 - A target ships *raw gradients* alongside model architecture: federated-learning client updates, "gradient logging" telemetry, distillation pipelines, or CTF artifacts pairing a small CNN definition with a saved gradient file (`.pt`, `.npy`, list of tensors whose shapes match model parameters).

--- a/skills/ai-threat-testing/reference/hopfield-recovery.md
+++ b/skills/ai-threat-testing/reference/hopfield-recovery.md
@@ -1,5 +1,7 @@
 # AI-ML — Hopfield / Spin-Glass Pattern Recovery
 
+> Category **`LLM08:2025`** Vector and Embedding Weaknesses. Authoritative mapping: [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
+
 When an AI-ML challenge ships a large symmetric weight matrix `W` and a generator notebook hinting at "associative memory", "energy minimisation", or "spin glass", you have a Hopfield network. The flag (or any hidden pattern) is encoded in stored patterns; recovery is via eigenspace seeding rather than naive iteration.
 
 ## Recognising the setup

--- a/skills/ai-threat-testing/reference/llm01-prompt-injection.md
+++ b/skills/ai-threat-testing/reference/llm01-prompt-injection.md
@@ -1,4 +1,6 @@
-# Agent: LLM01 Prompt Injection Testing
+# Agent: Prompt Injection Testing
+
+> Category **`LLM01:2025`** Prompt Injection. See [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm02-insecure-output.md
+++ b/skills/ai-threat-testing/reference/llm02-insecure-output.md
@@ -1,4 +1,6 @@
-# Agent: LLM02 Insecure Output Handling Testing
+# Agent: Insecure Output Handling Testing
+
+> Category **`LLM05:2025`** Improper Output Handling. The `llm02` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm03-training-poisoning.md
+++ b/skills/ai-threat-testing/reference/llm03-training-poisoning.md
@@ -1,4 +1,6 @@
-# Agent: LLM03 Training Data Poisoning Analysis
+# Agent: Training Data Poisoning Analysis
+
+> Category **`LLM04:2025`** Data and Model Poisoning. The `llm03` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm04-resource-exhaustion.md
+++ b/skills/ai-threat-testing/reference/llm04-resource-exhaustion.md
@@ -1,4 +1,6 @@
-# Agent: LLM04 Model Denial of Service Testing
+# Agent: Model Denial of Service Testing
+
+> Category **`LLM10:2025`** Unbounded Consumption. The `llm04` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm05-supply-chain.md
+++ b/skills/ai-threat-testing/reference/llm05-supply-chain.md
@@ -1,4 +1,6 @@
-# Agent: LLM05 Supply Chain Vulnerability Assessment
+# Agent: Supply Chain Vulnerability Assessment
+
+> Category **`LLM03:2025`** Supply Chain. The `llm05` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm06-excessive-agency.md
+++ b/skills/ai-threat-testing/reference/llm06-excessive-agency.md
@@ -1,4 +1,6 @@
-# Agent: LLM06 Excessive Agency / Privilege Escalation Testing
+# Agent: Excessive Agency / Privilege Escalation Testing
+
+> Category **`LLM06:2025`** Excessive Agency. See [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm07-model-extraction.md
+++ b/skills/ai-threat-testing/reference/llm07-model-extraction.md
@@ -1,4 +1,6 @@
-# Agent: LLM07 Model Extraction / Model Theft Testing
+# Agent: Model Extraction / Model Theft Testing
+
+> Category **`LLM10:2025`** Unbounded Consumption. The `llm07` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm08-vector-poisoning.md
+++ b/skills/ai-threat-testing/reference/llm08-vector-poisoning.md
@@ -1,4 +1,6 @@
-# Agent: LLM08 Vector Database Poisoning Testing
+# Agent: Vector Database Poisoning Testing
+
+> Category **`LLM08:2025`** Vector and Embedding Weaknesses. See [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm09-overreliance.md
+++ b/skills/ai-threat-testing/reference/llm09-overreliance.md
@@ -1,4 +1,6 @@
-# Agent: LLM09 Overreliance Vulnerability Testing
+# Agent: Overreliance Vulnerability Testing
+
+> Category **`LLM09:2025`** Misinformation. See [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/llm10-logging-bypass.md
+++ b/skills/ai-threat-testing/reference/llm10-logging-bypass.md
@@ -1,4 +1,6 @@
-# Agent: LLM10 Insufficient Logging & Monitoring Testing
+# Agent: Insufficient Logging & Monitoring Testing
+
+> Category **`TX-LLM-LOG-EVASION`** Monitoring evasion and forensic gaps in an LLM application. The `llm10` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
 
 ## Core Responsibilities
 

--- a/skills/ai-threat-testing/reference/malicious-keras-model-triage.md
+++ b/skills/ai-threat-testing/reference/malicious-keras-model-triage.md
@@ -1,5 +1,7 @@
 # Malicious Keras Model Triage
 
+> Category **`LLM03:2025`** Supply Chain. Authoritative mapping: [`reference/catalog/llm-top10-2025.json`](catalog/llm-top10-2025.json).
+
 ## When this applies
 
 - A `.keras`, `.h5`, or `SavedModel` artifact arrives without provenance and you must decide whether loading it is safe.

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm01-prompt-injection-direct.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm01-prompt-injection-direct.md
@@ -1,4 +1,6 @@
-# LLM01 — Direct Prompt Injection
+# Direct Prompt Injection
+
+> Category **`LLM01:2025`** Prompt Injection. See [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm01-prompt-injection-indirect.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm01-prompt-injection-indirect.md
@@ -1,4 +1,6 @@
-# LLM01 — Indirect Prompt Injection
+# Indirect Prompt Injection
+
+> Category **`LLM01:2025`** Prompt Injection. See [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm02-insecure-output-handling.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm02-insecure-output-handling.md
@@ -1,4 +1,6 @@
-# LLM02 — Insecure Output Handling
+# Insecure Output Handling
+
+> Category **`LLM05:2025`** Improper Output Handling. The `llm02` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm03-training-data-poisoning.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm03-training-data-poisoning.md
@@ -1,4 +1,6 @@
-# LLM03 — Training Data Poisoning
+# Training Data Poisoning
+
+> Category **`LLM04:2025`** Data and Model Poisoning. The `llm03` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm04-denial-of-service.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm04-denial-of-service.md
@@ -1,4 +1,6 @@
-# LLM04 — Denial of Service
+# Denial of Service
+
+> Category **`LLM10:2025`** Unbounded Consumption. The `llm04` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm05-supply-chain-vulnerabilities.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm05-supply-chain-vulnerabilities.md
@@ -1,4 +1,6 @@
-# LLM05 — Supply Chain Vulnerabilities
+# Supply Chain Vulnerabilities
+
+> Category **`LLM03:2025`** Supply Chain. The `llm05` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm06-sensitive-info-disclosure.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm06-sensitive-info-disclosure.md
@@ -1,4 +1,6 @@
-# LLM06 — Sensitive Information Disclosure
+# Sensitive Information Disclosure
+
+> Category **`LLM02:2025`** Sensitive Information Disclosure. The `llm06` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm07-insecure-plugin-design.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm07-insecure-plugin-design.md
@@ -1,4 +1,6 @@
-# LLM07 — Insecure Plugin Design
+# Insecure Plugin Design
+
+> Category **`LLM06:2025`** Excessive Agency. The `llm07` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/skills/ai-threat-testing/reference/scenarios/llm/llm08-excessive-agency.md
+++ b/skills/ai-threat-testing/reference/scenarios/llm/llm08-excessive-agency.md
@@ -1,4 +1,6 @@
-# LLM08 — Excessive Agency
+# Excessive Agency
+
+> Category **`LLM06:2025`** Excessive Agency. The `llm08` filename predates the 2025 renumbering and does not match the id; the authoritative mapping is [`reference/catalog/llm-top10-2025.json`](../../catalog/llm-top10-2025.json).
 
 ## When this applies
 

--- a/tools/test_llm_numbering.py
+++ b/tools/test_llm_numbering.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Pin the OWASP LLM Top 10 edition the ai-threat-testing skill claims.
+
+WHY THIS TEST EXISTS
+--------------------
+The skill carried two incompatible numbering schemes simultaneously. `reference/`
+used LLM06=Excessive Agency, LLM07=Model Extraction, LLM08=Vector Poisoning,
+LLM10=Insufficient Logging; `reference/scenarios/llm/` used the OWASP 2023 order
+(LLM06=Sensitive Information Disclosure, LLM07=Insecure Plugin Design,
+LLM08=Excessive Agency). So a report citing "OWASP LLM Top 10" contradicted itself
+depending on which file the agent had read, and "Insufficient Logging & Monitoring"
+was presented as LLM10 despite never being an OWASP LLM category in any edition.
+
+Filenames were left as they are — the content is right, only the label was wrong,
+and renaming would break inbound links. The catalogue is the source of truth, and
+this test is what stops the two drifting apart again.
+
+Run: python3 tools/test_llm_numbering.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, ".."))
+SKILL = os.path.join(REPO, "skills", "ai-threat-testing")
+CATALOG = os.path.join(SKILL, "reference", "catalog", "llm-top10-2025.json")
+
+# The OWASP Top 10 for LLM Applications, 2025 edition. Pinned here so that a
+# catalogue edit cannot quietly redefine what the framework says.
+OWASP_2025 = {
+    "LLM01:2025": "Prompt Injection",
+    "LLM02:2025": "Sensitive Information Disclosure",
+    "LLM03:2025": "Supply Chain",
+    "LLM04:2025": "Data and Model Poisoning",
+    "LLM05:2025": "Improper Output Handling",
+    "LLM06:2025": "Excessive Agency",
+    "LLM07:2025": "System Prompt Leakage",
+    "LLM08:2025": "Vector and Embedding Weaknesses",
+    "LLM09:2025": "Misinformation",
+    "LLM10:2025": "Unbounded Consumption",
+}
+
+
+def _catalog():
+    with open(CATALOG, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+class TestCatalogPinsOneEdition(unittest.TestCase):
+    def test_edition_is_declared_and_pinned(self):
+        meta = _catalog()["meta"]
+        self.assertEqual(meta["framework_version"], "2025")
+        self.assertIn("owasp.org", meta["source_url"])
+
+    def test_all_ten_categories_present_with_official_titles(self):
+        cats = {c["id"]: c["title"] for c in _catalog()["categories"]}
+        self.assertEqual(set(cats), set(OWASP_2025),
+                         "the catalogue must carry exactly the ten 2025 categories")
+        for cid, title in OWASP_2025.items():
+            self.assertEqual(cats[cid], title, f"{cid} title drifted from the pinned edition")
+
+    def test_every_category_is_covered_or_declares_a_gap(self):
+        """Silence reads as coverage — an uncovered category must say so."""
+        for c in _catalog()["categories"]:
+            if not c.get("covered_by"):
+                self.assertTrue(str(c.get("gap", "")).strip(),
+                                f"{c['id']} has no files and no gap statement")
+
+    def test_referenced_files_exist(self):
+        cat = _catalog()
+        missing = []
+        for group in ("categories", "local_classes"):
+            for c in cat[group]:
+                for rel in c.get("covered_by", []):
+                    if not os.path.isfile(os.path.join(SKILL, rel)):
+                        missing.append(f"{c['id']} -> {rel}")
+        self.assertEqual(missing, [], "catalogue cites files that do not exist")
+
+
+class TestNoInventedOwaspIds(unittest.TestCase):
+    """The defect that made the conformance claim false."""
+
+    def test_local_classes_never_use_an_llm_number(self):
+        for c in _catalog()["local_classes"]:
+            self.assertTrue(c["id"].startswith("TX-"),
+                            f"{c['id']} must use the TX- local namespace")
+            self.assertNotRegex(c["id"], r"LLM\d",
+                                "a non-OWASP class must never be given an LLMnn id — "
+                                "that is exactly how 'LLM10 Insufficient Logging' came about")
+
+    def test_logging_evasion_is_local_not_owasp(self):
+        """Named explicitly: it was presented as LLM10 and is in no edition."""
+        local = {c["id"] for c in _catalog()["local_classes"]}
+        self.assertIn("TX-LLM-LOG-EVASION", local)
+        titles = {c["title"].lower() for c in _catalog()["categories"]}
+        self.assertFalse(any("logging" in t or "monitoring" in t for t in titles),
+                         "logging/monitoring is not an OWASP LLM category")
+
+    def test_model_theft_is_filed_under_unbounded_consumption(self):
+        """A named client deliverable; it was filed under an invented LLM07."""
+        by_id = {c["id"]: c for c in _catalog()["categories"]}
+        files = by_id["LLM10:2025"]["covered_by"]
+        self.assertTrue(any("model-extraction" in f for f in files),
+                        "model extraction/theft belongs to LLM10:2025 Unbounded Consumption")
+        self.assertNotIn("reference/llm07-model-extraction.md",
+                         by_id["LLM07:2025"].get("covered_by", []),
+                         "LLM07:2025 is System Prompt Leakage, not Model Theft")
+
+    def test_no_file_is_claimed_by_two_categories(self):
+        seen, dupes = {}, []
+        cat = _catalog()
+        for group in ("categories", "local_classes"):
+            for c in cat[group]:
+                for rel in c.get("covered_by", []):
+                    if rel in seen:
+                        dupes.append(f"{rel}: {seen[rel]} and {c['id']}")
+                    seen[rel] = c["id"]
+        self.assertEqual(dupes, [], "a file addressing two categories makes coverage ambiguous")
+
+
+class TestSkillDoesNotAssertTheOldScheme(unittest.TestCase):
+    """SKILL.md is what an agent reads first; it propagated the wrong ids."""
+
+    def test_skill_md_carries_no_bare_llm_numbering_claim(self):
+        with open(os.path.join(SKILL, "SKILL.md"), encoding="utf-8") as fh:
+            body = fh.read()
+        # A bare "(LLM07)" with no edition is the ambiguity that started this.
+        bare = re.findall(r"\(LLM\d{2}\)(?!:)", body)
+        self.assertEqual(bare, [], "SKILL.md must qualify every id with its edition, e.g. LLM07:2025")
+
+    def test_skill_md_points_at_the_catalogue(self):
+        with open(os.path.join(SKILL, "SKILL.md"), encoding="utf-8") as fh:
+            body = fh.read()
+        self.assertIn("llm-top10-2025.json", body,
+                      "SKILL.md must route through the pinned catalogue, not a hand-written list")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_llm_numbering.py
+++ b/tools/test_llm_numbering.py
@@ -123,6 +123,56 @@ class TestNoInventedOwaspIds(unittest.TestCase):
         self.assertEqual(dupes, [], "a file addressing two categories makes coverage ambiguous")
 
 
+class TestEachFileDeclaresItsOwnCategory(unittest.TestCase):
+    """The part a catalogue alone does not fix.
+
+    Executors are handed a reference-file path, not SKILL.md — that is the repo's
+    stated convention. So a file whose own heading says "LLM07 Model Extraction"
+    still teaches the wrong id to every agent that reads it, however correct the
+    catalogue is. Each catalogued file must therefore name its category itself.
+    """
+
+    def _files(self):
+        cat = _catalog()
+        for group in ("categories", "local_classes"):
+            for c in cat[group]:
+                for rel in c.get("covered_by", []):
+                    yield rel, c["id"]
+
+    def test_no_heading_asserts_a_bare_llm_number(self):
+        offenders = []
+        for rel, _ in self._files():
+            with open(os.path.join(SKILL, rel), encoding="utf-8") as fh:
+                for line in fh:
+                    if line.startswith("#"):
+                        if re.search(r"LLM\d{2}(?!:)", line):
+                            offenders.append(f"{rel}: {line.strip()}")
+                        break
+        self.assertEqual(offenders, [],
+                         "a heading carrying an unqualified LLMnn re-teaches the old scheme")
+
+    def test_every_catalogued_file_states_its_category(self):
+        missing = []
+        for rel, cid in self._files():
+            with open(os.path.join(SKILL, rel), encoding="utf-8") as fh:
+                head = "".join(fh.readlines()[:6])
+            if cid not in head:
+                missing.append(f"{rel} does not name {cid} in its first 6 lines")
+        self.assertEqual(missing, [], "\n  ".join([""] + missing))
+
+    def test_the_three_that_were_actively_wrong(self):
+        """Named individually because these were the false claims."""
+        def head(rel):
+            with open(os.path.join(SKILL, rel), encoding="utf-8") as fh:
+                return "".join(fh.readlines()[:6])
+        self.assertIn("LLM10:2025", head("reference/llm07-model-extraction.md"),
+                      "model theft is Unbounded Consumption in 2025, not LLM07")
+        self.assertIn("TX-LLM-LOG-EVASION", head("reference/llm10-logging-bypass.md"),
+                      "monitoring evasion is not an OWASP category and must not claim LLM10")
+        self.assertIn("LLM02:2025", head("reference/scenarios/llm/llm06-sensitive-info-disclosure.md"),
+                      "sensitive information disclosure is LLM02 in 2025, not LLM06")
+
+
 class TestSkillDoesNotAssertTheOldScheme(unittest.TestCase):
     """SKILL.md is what an agent reads first; it propagated the wrong ids."""
 


### PR DESCRIPTION
## Summary

The ai-threat-testing skill carried two incompatible OWASP LLM numbering schemes at the same time: its `reference/` tree mixed 2025 ids (LLM06 Excessive Agency, LLM08 Vector) with 2023 ids (LLM07 Model Extraction, LLM09 Overreliance), while `reference/scenarios/llm/` was consistently 2023 — so a deliverable citing "OWASP LLM Top 10" contradicted itself depending on which file the agent happened to read, and "LLM10 Insufficient Logging & Monitoring" asserted conformance to a category that exists in neither edition. This pins the skill to the 2025 edition behind a machine-checked catalogue, records the one genuinely uncovered category as an explicit gap rather than letting silence read as coverage, and moves the two non-OWASP classes to a local `TX-` namespace. Filenames are deliberately untouched — the content was correct and only the labels were wrong, so renaming would break inbound links to fix nothing.

## Related Issue

Closes #54

## Changes Made

- Add `skills/ai-threat-testing/reference/catalog/llm-top10-2025.json` as the single source of truth for which reference file addresses which OWASP category, decoupling the claim from the filename; each of the ten 2025 categories carries its covering files, a note explaining its 2023→2025 movement, and an ATLAS xref where relevant
- Refile the categories that the old scheme got wrong: model extraction/theft moves under `LLM10:2025` Unbounded Consumption (2025 treats extraction-by-query as a consumption problem) instead of an invented LLM07, Insecure Plugin Design folds into `LLM06:2025` Excessive Agency, and Overreliance becomes `LLM09:2025` Misinformation
- Record `LLM07:2025` System Prompt Leakage as an explicit gap with no covering file — prompt extraction is touched inside the injection playbook, but what a system prompt *contains* that should not be there is a distinct finding from whether it can be extracted
- Move monitoring evasion / forensic gaps and adversarial perturbation of non-text input to local `TX-` ids: both are genuinely testable and are kept, but neither is an OWASP LLM Top 10 category, and giving a non-OWASP class an `LLMnn` number is precisely how the false "LLM10 Insufficient Logging" claim arose
- Rewrite the SKILL.md coverage section to route through the catalogue instead of a hand-written list, and require every cited id to carry its edition (`LLM06:2025`) since a bare `LLM06` resolves to two different categories
- Add `tools/test_llm_numbering.py` (10 tests): pins the 2025 category titles against drift, requires every category to be covered or to declare a gap, verifies every cited file exists, forbids a local class from taking an LLM number, asserts model theft sits under LLM10 rather than LLM07, rejects a bare unqualified `(LLMnn)` in SKILL.md, and requires SKILL.md to reference the catalogue
- Wire the new test into the CI job and add the `skills/ai-threat-testing/**` path trigger to both the pull_request and push filters — without that path the check would exist but never execute on the changes it validates

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New skill or agent
- [ ] Enhancement to existing skill/agent
- [ ] Documentation update
- [ ] CI/CD or infrastructure
- [ ] Refactoring (no functional change)
- [ ] Other: fix

## Testing

- [ ] Tested skill/agent in Claude Code session
- [ ] Tested against vulnerable application (DVWA, WebGoat, Juice Shop, etc.)
- [ ] Verified no false positives
- [x] Ran existing tests
- [ ] Manual review only (documentation/config changes)

**Test details:**

**Content guard:** `/content-guard` — **CLEAN**
- changed-scope: 4 item(s) scanned (every blob this branch introduces, plus worktree, index and untracked)
- whole-tree backstop: 1208 item(s) scanned
- client-name lane: active
- tree digest: `fe9388f44474b228`


## Checklist

- [x] My code follows the contribution guidelines
- [x] Commits use conventional format: `type: description`
- [ ] I've updated documentation where needed
- [ ] New skills include `SKILL.md` and `reference/` directory
- [x] No secrets, credentials, or unauthorized target information included
- [x] This PR links to an issue with `Closes #N`

## Skill / agent checklist

- [ ] `python3 scripts/skill_linter.py` runs clean (or rationale below).
- [ ] No new challenge-specific identifiers outside `skills/hackthebox/`.
- [ ] `SKILL.md` ≤ 150 lines; `reference/*.md` ≤ 200 lines.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

